### PR TITLE
Update o-comments to the latest version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "o-header": "^7.2.8",
     "o-footer": "^6.0.8",
     "o-teaser": "^2.3.2",
-    "o-comments": "^5",
+    "o-comments": "6.0.0-beta.50",
     "o-share": "^6.1.0",
     "o-ads": "^10.2.0",
     "o-date": "^2.10.3",

--- a/components/comments/index.js
+++ b/components/comments/index.js
@@ -13,13 +13,12 @@ class Comments extends PureComponent {
   ref = React.createRef();
 
   async componentDidMount() {
-    const { title, id, url } = this.props;
+    const { id, url } = this.props;
 
     // prettier-ignore
     new OComments(this.ref.current, { // eslint-disable-line no-new
-      title,
-      url,
-      articleId: id,
+      articleUrl: url,
+      articleId: id
     });
   }
 
@@ -34,7 +33,6 @@ class Comments extends PureComponent {
             ref={this.ref}
             data-o-component="o-comments"
             id="comments"
-            data-o-comments-auto-init="false"
             data-o-grid-colspan="12 S11 Scenter M9 L8 XL7"
           >
             <div className="o--if-no-js">

--- a/stories/__snapshots__/Storyshots.test.js.snap
+++ b/stories/__snapshots__/Storyshots.test.js.snap
@@ -2691,7 +2691,6 @@ exports[`Storyshots Comments default 1`] = `
         className="o-grid-row"
       >
         <div
-          data-o-comments-auto-init="false"
           data-o-component="o-comments"
           data-o-grid-colspan="12 S11 Scenter M9 L8 XL7"
           id="comments"
@@ -7105,7 +7104,6 @@ soluta vix, quis natum ne qui, ei vidit latine partiendo mei. Mel ea duis essent
         className="o-grid-row"
       >
         <div
-          data-o-comments-auto-init="false"
           data-o-component="o-comments"
           data-o-grid-colspan="12 S11 Scenter M9 L8 XL7"
           id="comments"
@@ -9398,7 +9396,6 @@ soluta vix, quis natum ne qui, ei vidit latine partiendo mei. Mel ea duis essent
         className="o-grid-row"
       >
         <div
-          data-o-comments-auto-init="false"
           data-o-component="o-comments"
           data-o-grid-colspan="12 S11 Scenter M9 L8 XL7"
           id="comments"
@@ -12221,7 +12218,6 @@ soluta vix, quis natum ne qui, ei vidit latine partiendo mei. Mel ea duis essent
         className="o-grid-row"
       >
         <div
-          data-o-comments-auto-init="false"
           data-o-component="o-comments"
           data-o-grid-colspan="12 S11 Scenter M9 L8 XL7"
           id="comments"
@@ -14488,7 +14484,6 @@ soluta vix, quis natum ne qui, ei vidit latine partiendo mei. Mel ea duis essent
           className="o-grid-row"
         >
           <div
-            data-o-comments-auto-init="false"
             data-o-component="o-comments"
             data-o-grid-colspan="12 S11 Scenter M9 L8 XL7"
             id="comments"
@@ -17315,7 +17310,6 @@ soluta vix, quis natum ne qui, ei vidit latine partiendo mei. Mel ea duis essent
           className="o-grid-row"
         >
           <div
-            data-o-comments-auto-init="false"
             data-o-component="o-comments"
             data-o-grid-colspan="12 S11 Scenter M9 L8 XL7"
             id="comments"


### PR DESCRIPTION
This is bumping o-comments to use the new provider Coral Talk.

There is very little difference in the interface so not much needed to
change but underneith there is a lot of difference and this will soon be
released as a new breaking version v6.