### PR TITLE
Ge2019 constituency results table

### DIFF
--- a/components/elections/constituency-results-table/index.js
+++ b/components/elections/constituency-results-table/index.js
@@ -1,0 +1,19 @@
+/**
+ * @file
+ * Constituency results table component
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export const ConstituencyResultsTable = ({ className }) => <div className={className}></div>;
+
+ConstituencyResultsTable.propTypes = {
+  className: PropTypes.string,
+};
+
+ConstituencyResultsTable.defaultProps = {
+  className: 'g-constituency-results-table',
+};
+
+export default ConstituencyResultsTable;

--- a/components/elections/constituency-results-table/index.js
+++ b/components/elections/constituency-results-table/index.js
@@ -8,14 +8,7 @@ import PropTypes from 'prop-types';
 import { numberWithCommas, getPartyInfo } from '../utils';
 import './styles.scss';
 
-export const ConstituencyResultsTable = ({
-  className,
-  data,
-  tableHeaders,
-  showAsterickField,
-  note,
-  width,
-}) => (
+export const ConstituencyResultsTable = ({ className, data, tableHeaders, note }) => (
   <div className={className}>
     <table className={`${className}__table`}>
       <thead>
@@ -59,7 +52,6 @@ ConstituencyResultsTable.propTypes = {
     }),
   ).isRequired,
   tableHeaders: PropTypes.arrayOf(PropTypes.string).isRequired,
-  width: PropTypes.number,
   note: PropTypes.string,
 };
 

--- a/components/elections/constituency-results-table/index.js
+++ b/components/elections/constituency-results-table/index.js
@@ -14,28 +14,31 @@ export const ConstituencyResultsTable = ({
   tableHeaders,
   showAsterickField,
   note,
+  width,
 }) => (
   <div className={className}>
     <table className={`${className}__table`}>
       <thead>
         <tr>
           {tableHeaders.map(t => (
-            <th>{t}</th>
+            <th key={`th_${t}`}>{t}</th>
           ))}
         </tr>
       </thead>
       <tbody>
-        {data.map(d => {
-          const fields = Object.entries(d).filter(([field]) => field !== 'showAsterick');
-          const showAsterick = d.showAsterick;
+        {data.map(({ party, candidate, votes, showAsterick }) => {
+          const { shortName, color } = getPartyInfo(party);
           return (
-            <tr>
-              {fields.map(([field, value]) => (
-                <td>
-                  {value}
-                  {showAsterickField === field && showAsterick ? '*' : ''}
-                </td>
-              ))}
+            <tr key={`row_${party}`}>
+              <td>
+                <span className="party-badge" style={{ backgroundColor: color }} />
+                {shortName}
+              </td>
+              <td>
+                {candidate}
+                {showAsterick && '*'}
+              </td>
+              <td className="number">{numberWithCommas(votes)}</td>
             </tr>
           );
         })}
@@ -47,16 +50,21 @@ export const ConstituencyResultsTable = ({
 
 ConstituencyResultsTable.propTypes = {
   className: PropTypes.string,
-  data: PropTypes.arrayOf(PropTypes.object).isRequired,
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      party: PropTypes.string,
+      candidate: PropTypes.string,
+      votes: PropTypes.number,
+      showAsterick: PropTypes.bool.isOptional,
+    }),
+  ).isRequired,
   tableHeaders: PropTypes.arrayOf(PropTypes.string).isRequired,
   width: PropTypes.number,
   note: PropTypes.string,
-  showAsterickField: PropTypes.string,
 };
 
 ConstituencyResultsTable.defaultProps = {
   className: 'g-constituency-results-table',
-  width: 500,
 };
 
 export default ConstituencyResultsTable;

--- a/components/elections/constituency-results-table/index.js
+++ b/components/elections/constituency-results-table/index.js
@@ -5,15 +5,58 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { numberWithCommas, getPartyInfo } from '../utils';
+import './styles.scss';
 
-export const ConstituencyResultsTable = ({ className }) => <div className={className}></div>;
+export const ConstituencyResultsTable = ({
+  className,
+  data,
+  tableHeaders,
+  showAsterickField,
+  note,
+}) => (
+  <div className={className}>
+    <table className={`${className}__table`}>
+      <thead>
+        <tr>
+          {tableHeaders.map(t => (
+            <th>{t}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {data.map(d => {
+          const fields = Object.entries(d).filter(([field]) => field !== 'showAsterick');
+          const showAsterick = d.showAsterick;
+          return (
+            <tr>
+              {fields.map(([field, value]) => (
+                <td>
+                  {value}
+                  {showAsterickField === field && showAsterick ? '*' : ''}
+                </td>
+              ))}
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+    {note && <div className={`${className}__note`}>{note}</div>}
+  </div>
+);
 
 ConstituencyResultsTable.propTypes = {
   className: PropTypes.string,
+  data: PropTypes.arrayOf(PropTypes.object).isRequired,
+  tableHeaders: PropTypes.arrayOf(PropTypes.string).isRequired,
+  width: PropTypes.number,
+  note: PropTypes.string,
+  showAsterickField: PropTypes.string,
 };
 
 ConstituencyResultsTable.defaultProps = {
   className: 'g-constituency-results-table',
+  width: 500,
 };
 
 export default ConstituencyResultsTable;

--- a/components/elections/constituency-results-table/styles.scss
+++ b/components/elections/constituency-results-table/styles.scss
@@ -1,0 +1,4 @@
+.g-constituency-results-table {
+  &__table {
+  }
+}

--- a/components/elections/constituency-results-table/styles.scss
+++ b/components/elections/constituency-results-table/styles.scss
@@ -1,4 +1,91 @@
+@import 'o-grid/main';
+
 .g-constituency-results-table {
+  width: 100%;
+
   &__table {
+    width: 100%;
+    border-collapse: collapse;
+
+    thead tr th {
+      color: rgba(38, 42, 51, 0.8);
+      font-size: 14px;
+      font-weight: normal;
+      line-height: 1.29;
+      letter-spacing: 0.3px;
+      text-transform: uppercase;
+      padding-bottom: 6px;
+      border-bottom: solid 1px;
+      border-bottom-color: #999189;
+
+      @include oGridRespondTo(M) {
+        border-bottom-color: #ccc1b7;
+      }
+
+      vertical-align: bottom;
+
+      // First two children
+      &:nth-child(-n + 2) {
+        text-align: left;
+      }
+
+      &:last-child {
+        text-align: right;
+        max-width: 40px;
+
+        @include oGridRespondTo(M) {
+          max-width: none;
+        }
+      }
+    }
+
+    tbody tr td {
+      height: 40px;
+      line-height: 40px;
+      font-size: 18px;
+      font-weight: normal;
+      color: rgba(0, 0, 0, 0.9);
+      border-bottom: solid 1px;
+      border-bottom-color: #ccc1b7;
+
+      @include oGridRespondTo(M) {
+        border-bottom-color: #f2e5da;
+      }
+
+      // First two children
+      &:nth-child(-n + 2) {
+        text-align: left;
+      }
+
+      &:last-child {
+        text-align: right;
+      }
+
+      &.number {
+        font-feature-settings: 'tnum';
+      }
+
+      .party-badge {
+        display: inline-block;
+        height: 25px;
+        position: relative;
+        top: 7px;
+        margin-right: 10px;
+        width: 4px;
+
+        @include oGridRespondTo(M) {
+          width: 8px;
+        }
+      }
+    }
+  }
+
+  &__note {
+    text-align: right;
+    margin-top: 7px;
+    font-size: 14px;
+    font-weight: normal;
+    letter-spacing: 0.26px;
+    color: #66605c;
   }
 }

--- a/components/elections/utils.js
+++ b/components/elections/utils.js
@@ -105,4 +105,8 @@ export const getPartyInfo = name => {
   }
 };
 
+export const numberWithCommas = x => {
+  return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+};
+
 export default null;

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -26,6 +26,7 @@ import AutosuggestSearch from '../components/autosuggest-search';
 import { getPartyInfo } from '../components/elections/utils';
 import LastUpdated from '../components/last-updated';
 import DateTime from '../components/datetime';
+import ConstituencyResultsTable from '../components/elections/constituency-results-table';
 import '../shared/critical-path.scss';
 
 const defaultFlags = {
@@ -1140,3 +1141,5 @@ storiesOf('LastUpdated', module)
 storiesOf('DateTime', module).add('default', () => (
   <DateTime datestamp={new Date('1987-01-05T00:00:00.00')} />
 ));
+
+storiesOf('ConstituencyResultsTable', module).add('default', () => <ConstituencyResultsTable />);

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -1152,7 +1152,6 @@ storiesOf('ConstituencyResultsTable', module).add('default', () => (
       { party: 'Independent', candidate: 'Nick Yeomans', votes: 376 },
     ]}
     tableHeaders={['Party', 'Candidate', 'Total Votes']}
-    showAsterickField="candidate"
     note={'* Note to indicate outgoing candidate'}
   />
 ));

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -1142,4 +1142,17 @@ storiesOf('DateTime', module).add('default', () => (
   <DateTime datestamp={new Date('1987-01-05T00:00:00.00')} />
 ));
 
-storiesOf('ConstituencyResultsTable', module).add('default', () => <ConstituencyResultsTable />);
+storiesOf('ConstituencyResultsTable', module).add('default', () => (
+  <ConstituencyResultsTable
+    data={[
+      { party: 'Green', candidate: 'Caroline Lucas', votes: 30149, showAsterick: true },
+      { party: 'Labour', candidate: 'Solomon Curtis', votes: 15450 },
+      { party: 'Conservative', candidate: 'Emma Warman', votes: 11082 },
+      { party: 'Ukip', candidate: 'Ian Buchanan', votes: 630 },
+      { party: 'Independent', candidate: 'Nick Yeomans', votes: 376 },
+    ]}
+    tableHeaders={['Party', 'Candidate', 'Total Votes']}
+    showAsterickField="candidate"
+    note={'* Note to indicate outgoing candidate'}
+  />
+));


### PR DESCRIPTION
Adds results table for constituency cards
- Can configure table headers and add a custom note

Closes https://github.com/Financial-Times/djd-ge2019-results-page/issues/13