### PR TITLE
Removes Google+ meta tag as it's no longer relevant.

### DIFF
--- a/components/html-head/index.js
+++ b/components/html-head/index.js
@@ -60,7 +60,6 @@ const HtmlHead = ({
 
       {stylesheets && stylesheets.map(stylesheet => <link rel="stylesheet" href={stylesheet} />)}
 
-      <link href="https://plus.google.com/113457471429583444041/" rel="publisher" />
       <meta property="fb:app_id" content="429755910551755" />
       <link
         rel="icon"


### PR DESCRIPTION
See: https://support.google.com/webmasters/thread/3064840?hl=en

Closes #30.