### PR TITLE
Remove projection legend when no projections

### DIFF
--- a/components/elections/constituency-lookup/index.stories.mdx
+++ b/components/elections/constituency-lookup/index.stories.mdx
@@ -1,7 +1,6 @@
 import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
 import '../../../shared/critical-path.scss';
 import ConstituencyLookup from './';
-import { csvParse } from 'd3-dsv';
 import candidateList from '../sample-data/candidates.json';
 import constituencyList from '../sample-data/constituencies.json';
 

--- a/components/elections/sample-data/results/end.json
+++ b/components/elections/sample-data/results/end.json
@@ -1,0 +1,162 @@
+[
+  {
+    "partyName": "Alliance",
+    "partySeats": 0,
+    "partySeatsNewlyWon": 0,
+    "partySeatsNewlyLost": 0,
+    "partySeatsChange": 0,
+    "partySeatsForecast": null,
+    "partyVotes": 35561,
+    "partySharePercentage": 0.12424662317062386
+  },
+  {
+    "partyName": "Brexit",
+    "partySeats": 3,
+    "partySeatsNewlyWon": 3,
+    "partySeatsNewlyLost": 0,
+    "partySeatsChange": 3,
+    "partySeatsForecast": null,
+    "partyVotes": 791974,
+    "partySharePercentage": 2.7670789668156592
+  },
+  {
+    "partyName": "Conservative",
+    "partySeats": 332,
+    "partySeatsNewlyWon": 160,
+    "partySeatsNewlyLost": 127,
+    "partySeatsChange": 33,
+    "partySeatsForecast": null,
+    "partyVotes": 10684851,
+    "partySharePercentage": 37.33181451115727
+  },
+  {
+    "partyName": "DUP",
+    "partySeats": 7,
+    "partySeatsNewlyWon": 3,
+    "partySeatsNewlyLost": 6,
+    "partySeatsChange": -3,
+    "partySeatsForecast": null,
+    "partyVotes": 227963,
+    "partySharePercentage": 0.796480215906328
+  },
+  {
+    "partyName": "Green",
+    "partySeats": 6,
+    "partySeatsNewlyWon": 6,
+    "partySeatsNewlyLost": 1,
+    "partySeatsChange": 5,
+    "partySeatsForecast": null,
+    "partyVotes": 1561032,
+    "partySharePercentage": 5.454091692058303
+  },
+  {
+    "partyName": "Independent Group for Change",
+    "partySeats": 1,
+    "partySeatsNewlyWon": 0,
+    "partySeatsNewlyLost": 2,
+    "partySeatsChange": -2,
+    "partySeatsForecast": null,
+    "partyVotes": 16964,
+    "partySharePercentage": 0.059270541195873654
+  },
+  {
+    "partyName": "Independent/Other",
+    "partySeats": 0,
+    "partySeatsNewlyWon": 0,
+    "partySeatsNewlyLost": 27,
+    "partySeatsChange": -27,
+    "partySeatsForecast": null,
+    "partyVotes": 558655,
+    "partySharePercentage": 1.951885415690922
+  },
+  {
+    "partyName": "Labour",
+    "partySeats": 178,
+    "partySeatsNewlyWon": 103,
+    "partySeatsNewlyLost": 169,
+    "partySeatsChange": -66,
+    "partySeatsForecast": null,
+    "partyVotes": 8301813,
+    "partySharePercentage": 29.005715009251325
+  },
+  {
+    "partyName": "Liberal Democrats",
+    "partySeats": 57,
+    "partySeatsNewlyWon": 55,
+    "partySeatsNewlyLost": 18,
+    "partySeatsChange": 37,
+    "partySeatsForecast": null,
+    "partyVotes": 4418852,
+    "partySharePercentage": 15.439032628181367
+  },
+  {
+    "partyName": "Plaid Cymru",
+    "partySeats": 9,
+    "partySeatsNewlyWon": 7,
+    "partySeatsNewlyLost": 2,
+    "partySeatsChange": 5,
+    "partySeatsForecast": null,
+    "partyVotes": 318029,
+    "partySharePercentage": 1.1111619279640712
+  },
+  {
+    "partyName": "SDLP",
+    "partySeats": 3,
+    "partySeatsNewlyWon": 3,
+    "partySeatsNewlyLost": 0,
+    "partySeatsChange": 3,
+    "partySeatsForecast": null,
+    "partyVotes": 97863,
+    "partySharePercentage": 0.3419236602836468
+  },
+  {
+    "partyName": "Sinn Féin",
+    "partySeats": 7,
+    "partySeatsNewlyWon": 4,
+    "partySeatsNewlyLost": 4,
+    "partySeatsChange": 0,
+    "partySeatsForecast": null,
+    "partyVotes": 231012,
+    "partySharePercentage": 0.807133120887831
+  },
+  {
+    "partyName": "SNP",
+    "partySeats": 45,
+    "partySeatsNewlyWon": 16,
+    "partySeatsNewlyLost": 6,
+    "partySeatsChange": 10,
+    "partySeatsForecast": null,
+    "partyVotes": 1148133,
+    "partySharePercentage": 4.011463350320798
+  },
+  {
+    "partyName": "The Speaker",
+    "partySeats": 1,
+    "partySeatsNewlyWon": 0,
+    "partySeatsNewlyLost": 0,
+    "partySeatsChange": 0,
+    "partySeatsForecast": null,
+    "partyVotes": 23782,
+    "partySharePercentage": 0.08309196007546966
+  },
+  {
+    "partyName": "Ukip",
+    "partySeats": 0,
+    "partySeatsNewlyWon": 0,
+    "partySeatsNewlyLost": 0,
+    "partySeatsChange": 0,
+    "partySeatsForecast": null,
+    "partyVotes": 88005,
+    "partySharePercentage": 0.30748078153400504
+  },
+  {
+    "partyName": "UUP",
+    "partySeats": 1,
+    "partySeatsNewlyWon": 1,
+    "partySeatsNewlyLost": 0,
+    "partySeatsChange": 1,
+    "partySeatsForecast": null,
+    "partyVotes": 116812,
+    "partySharePercentage": 0.4081295955065075
+  }
+]

--- a/components/elections/sample-data/results/middle.json
+++ b/components/elections/sample-data/results/middle.json
@@ -1,0 +1,155 @@
+[
+  {
+    "partyName": "Alliance",
+    "partySeats": 0,
+    "partySeatsNewlyWon": 0,
+    "partySeatsNewlyLost": 0,
+    "partySeatsChange": 0,
+    "partyVotes": 22001,
+    "partySharePercentage": 0.14317197673899518
+  },
+  {
+    "partyName": "Brexit",
+    "partySeats": 1,
+    "partySeatsNewlyWon": 1,
+    "partySeatsNewlyLost": 0,
+    "partySeatsChange": 1,
+    "partySeatsForecast": 1,
+    "partyVotes": 456538,
+    "partySharePercentage": 2.970930772077059
+  },
+  {
+    "partyName": "Conservative",
+    "partySeats": 183,
+    "partySeatsNewlyWon": 90,
+    "partySeatsNewlyLost": 205,
+    "partySeatsChange": -115,
+    "partySeatsForecast": 335,
+    "partyVotes": 5761003,
+    "partySharePercentage": 37.489849893608536
+  },
+  {
+    "partyName": "DUP",
+    "partySeats": 3,
+    "partySeatsNewlyWon": 0,
+    "partySeatsNewlyLost": 7,
+    "partySeatsChange": -7,
+    "partyVotes": 104909,
+    "partySharePercentage": 0.6826975550071016
+  },
+  {
+    "partyName": "Green",
+    "partySeats": 2,
+    "partySeatsNewlyWon": 2,
+    "partySeatsNewlyLost": 1,
+    "partySeatsChange": 1,
+    "partySeatsForecast": 3,
+    "partyVotes": 775700,
+    "partySharePercentage": 5.04788429418838
+  },
+  {
+    "partyName": "Independent Group for Change",
+    "partySeats": 1,
+    "partySeatsNewlyWon": 0,
+    "partySeatsNewlyLost": 2,
+    "partySeatsChange": -2,
+    "partyVotes": 12431,
+    "partySharePercentage": 0.08089499762930999
+  },
+  {
+    "partyName": "Independent/Other",
+    "partySeats": 1,
+    "partySeatsNewlyWon": 0,
+    "partySeatsNewlyLost": 25,
+    "partySeatsChange": -25,
+    "partySeatsForecast": 1,
+    "partyVotes": 333197,
+    "partySharePercentage": 2.1682865839508647
+  },
+  {
+    "partyName": "Labour",
+    "partySeats": 86,
+    "partySeatsNewlyWon": 50,
+    "partySeatsNewlyLost": 208,
+    "partySeatsChange": -158,
+    "partySeatsForecast": 185,
+    "partyVotes": 4296408,
+    "partySharePercentage": 27.95896669411539
+  },
+  {
+    "partyName": "Liberal Democrats",
+    "partySeats": 35,
+    "partySeatsNewlyWon": 33,
+    "partySeatsNewlyLost": 18,
+    "partySeatsChange": 15,
+    "partySeatsForecast": 48,
+    "partyVotes": 2493366,
+    "partySharePercentage": 16.22563242369899
+  },
+  {
+    "partyName": "Plaid Cymru",
+    "partySeats": 7,
+    "partySeatsNewlyWon": 5,
+    "partySeatsNewlyLost": 2,
+    "partySeatsChange": 3,
+    "partySeatsForecast": 8,
+    "partyVotes": 214879,
+    "partySharePercentage": 1.3983296754555947
+  },
+  {
+    "partyName": "SDLP",
+    "partySeats": 1,
+    "partySeatsNewlyWon": 1,
+    "partySeatsNewlyLost": 0,
+    "partySeatsChange": 1,
+    "partyVotes": 39236,
+    "partySharePercentage": 0.25532910682838117
+  },
+  {
+    "partyName": "Sinn Féin",
+    "partySeats": 4,
+    "partySeatsNewlyWon": 2,
+    "partySeatsNewlyLost": 5,
+    "partySeatsChange": -3,
+    "partyVotes": 107831,
+    "partySharePercentage": 0.7017125323277391
+  },
+  {
+    "partyName": "SNP",
+    "partySeats": 26,
+    "partySeatsNewlyWon": 10,
+    "partySeatsNewlyLost": 19,
+    "partySeatsChange": -9,
+    "partySeatsForecast": 50,
+    "partyVotes": 641672,
+    "partySharePercentage": 4.17569422562904
+  },
+  {
+    "partyName": "The Speaker",
+    "partySeats": 1,
+    "partySeatsNewlyWon": 0,
+    "partySeatsNewlyLost": 0,
+    "partySeatsChange": 0,
+    "partySeatsForecast": null,
+    "partyVotes": 23782,
+    "partySharePercentage": 0.15476187222429813
+  },
+  {
+    "partyName": "Ukip",
+    "partySeats": 0,
+    "partySeatsNewlyWon": 0,
+    "partySeatsNewlyLost": 0,
+    "partySeatsChange": 0,
+    "partyVotes": 41015,
+    "partySharePercentage": 0.266905987271028
+  },
+  {
+    "partyName": "UUP",
+    "partySeats": 0,
+    "partySeatsNewlyWon": 0,
+    "partySeatsNewlyLost": 0,
+    "partySeatsChange": 0,
+    "partyVotes": 42866,
+    "partySharePercentage": 0.27895140924929623
+  }
+]

--- a/components/elections/sample-data/results/start.json
+++ b/components/elections/sample-data/results/start.json
@@ -1,0 +1,146 @@
+[
+  {
+    "partyName": "Alliance",
+    "partySeats": 0,
+    "partySeatsNewlyWon": 0,
+    "partySeatsNewlyLost": 0,
+    "partySeatsChange": 0,
+    "partyVotes": 1832,
+    "partySharePercentage": 0.42741922313289893
+  },
+  {
+    "partyName": "Brexit",
+    "partySeats": 0,
+    "partySeatsNewlyWon": 0,
+    "partySeatsNewlyLost": 0,
+    "partySeatsChange": 0,
+    "partyVotes": 7278,
+    "partySharePercentage": 1.6980115207211999
+  },
+  {
+    "partyName": "Conservative",
+    "partySeats": 5,
+    "partySeatsNewlyWon": 2,
+    "partySeatsNewlyLost": 294,
+    "partySeatsChange": -292,
+    "partyVotes": 140173,
+    "partySharePercentage": 32.70340325557196
+  },
+  {
+    "partyName": "DUP",
+    "partySeats": 0,
+    "partySeatsNewlyWon": 0,
+    "partySeatsNewlyLost": 10,
+    "partySeatsChange": -10,
+    "partyVotes": 6188,
+    "partySharePercentage": 1.4437064152545733
+  },
+  {
+    "partyName": "Green",
+    "partySeats": 0,
+    "partySeatsNewlyWon": 0,
+    "partySeatsNewlyLost": 1,
+    "partySeatsChange": -1,
+    "partyVotes": 17023,
+    "partySharePercentage": 3.971592486567324
+  },
+  {
+    "partyName": "Independent Group for Change",
+    "partySeats": 0,
+    "partySeatsNewlyWon": 0,
+    "partySeatsNewlyLost": 3,
+    "partySeatsChange": -3,
+    "partyVotes": 0,
+    "partySharePercentage": 0
+  },
+  {
+    "partyName": "Independent/Other",
+    "partySeats": 0,
+    "partySeatsNewlyWon": 0,
+    "partySeatsNewlyLost": 24,
+    "partySeatsChange": -24,
+    "partyVotes": 6756,
+    "partySharePercentage": 1.576225039020669
+  },
+  {
+    "partyName": "Labour",
+    "partySeats": 1,
+    "partySeatsNewlyWon": 1,
+    "partySeatsNewlyLost": 245,
+    "partySeatsChange": -244,
+    "partyVotes": 96662,
+    "partySharePercentage": 22.55196339872941
+  },
+  {
+    "partyName": "Liberal Democrats",
+    "partySeats": 1,
+    "partySeatsNewlyWon": 1,
+    "partySeatsNewlyLost": 21,
+    "partySeatsChange": -20,
+    "partyVotes": 47937,
+    "partySharePercentage": 11.184058569498784
+  },
+  {
+    "partyName": "Plaid Cymru",
+    "partySeats": 0,
+    "partySeatsNewlyWon": 0,
+    "partySeatsNewlyLost": 4,
+    "partySeatsChange": -4,
+    "partyVotes": 1322,
+    "partySharePercentage": 0.30843243066686266
+  },
+  {
+    "partyName": "SDLP",
+    "partySeats": 0,
+    "partySeatsNewlyWon": 0,
+    "partySeatsNewlyLost": 0,
+    "partySeatsChange": 0,
+    "partyVotes": 1190,
+    "partySharePercentage": 0.27763584908741795
+  },
+  {
+    "partyName": "Sinn Féin",
+    "partySeats": 1,
+    "partySeatsNewlyWon": 0,
+    "partySeatsNewlyLost": 6,
+    "partySeatsChange": -6,
+    "partyVotes": 19124,
+    "partySharePercentage": 4.461771410040153
+  },
+  {
+    "partyName": "SNP",
+    "partySeats": 4,
+    "partySeatsNewlyWon": 1,
+    "partySeatsNewlyLost": 32,
+    "partySeatsChange": -31,
+    "partyVotes": 83134,
+    "partySharePercentage": 19.39578040170874
+  },
+  {
+    "partyName": "The Speaker",
+    "partySeats": 0,
+    "partySeatsNewlyWon": 0,
+    "partySeatsNewlyLost": 1,
+    "partySeatsChange": -1,
+    "partyVotes": 0,
+    "partySharePercentage": 0
+  },
+  {
+    "partyName": "Ukip",
+    "partySeats": 0,
+    "partySeatsNewlyWon": 0,
+    "partySeatsNewlyLost": 0,
+    "partySeatsChange": 0,
+    "partyVotes": 0,
+    "partySharePercentage": 0
+  },
+  {
+    "partyName": "UUP",
+    "partySeats": 0,
+    "partySeatsNewlyWon": 0,
+    "partySeatsNewlyLost": 0,
+    "partySeatsChange": 0,
+    "partyVotes": 0,
+    "partySharePercentage": 0
+  }
+]

--- a/components/elections/sample-data/results/start.json
+++ b/components/elections/sample-data/results/start.json
@@ -6,7 +6,7 @@
     "partySeatsNewlyLost": 0,
     "partySeatsChange": 0,
     "partyVotes": 1832,
-    "partySharePercentage": 0.42741922313289893
+    "partySharePercentage": null
   },
   {
     "partyName": "Brexit",
@@ -15,7 +15,7 @@
     "partySeatsNewlyLost": 0,
     "partySeatsChange": 0,
     "partyVotes": 7278,
-    "partySharePercentage": 1.6980115207211999
+    "partySharePercentage": null
   },
   {
     "partyName": "Conservative",
@@ -24,7 +24,7 @@
     "partySeatsNewlyLost": 294,
     "partySeatsChange": -292,
     "partyVotes": 140173,
-    "partySharePercentage": 32.70340325557196
+    "partySharePercentage": null
   },
   {
     "partyName": "DUP",
@@ -33,7 +33,7 @@
     "partySeatsNewlyLost": 10,
     "partySeatsChange": -10,
     "partyVotes": 6188,
-    "partySharePercentage": 1.4437064152545733
+    "partySharePercentage": null
   },
   {
     "partyName": "Green",
@@ -42,7 +42,7 @@
     "partySeatsNewlyLost": 1,
     "partySeatsChange": -1,
     "partyVotes": 17023,
-    "partySharePercentage": 3.971592486567324
+    "partySharePercentage": null
   },
   {
     "partyName": "Independent Group for Change",
@@ -51,7 +51,7 @@
     "partySeatsNewlyLost": 3,
     "partySeatsChange": -3,
     "partyVotes": 0,
-    "partySharePercentage": 0
+    "partySharePercentage": null
   },
   {
     "partyName": "Independent/Other",
@@ -60,7 +60,7 @@
     "partySeatsNewlyLost": 24,
     "partySeatsChange": -24,
     "partyVotes": 6756,
-    "partySharePercentage": 1.576225039020669
+    "partySharePercentage": null
   },
   {
     "partyName": "Labour",
@@ -69,7 +69,7 @@
     "partySeatsNewlyLost": 245,
     "partySeatsChange": -244,
     "partyVotes": 96662,
-    "partySharePercentage": 22.55196339872941
+    "partySharePercentage": null
   },
   {
     "partyName": "Liberal Democrats",
@@ -78,7 +78,7 @@
     "partySeatsNewlyLost": 21,
     "partySeatsChange": -20,
     "partyVotes": 47937,
-    "partySharePercentage": 11.184058569498784
+    "partySharePercentage": null
   },
   {
     "partyName": "Plaid Cymru",
@@ -87,7 +87,7 @@
     "partySeatsNewlyLost": 4,
     "partySeatsChange": -4,
     "partyVotes": 1322,
-    "partySharePercentage": 0.30843243066686266
+    "partySharePercentage": null
   },
   {
     "partyName": "SDLP",
@@ -96,7 +96,7 @@
     "partySeatsNewlyLost": 0,
     "partySeatsChange": 0,
     "partyVotes": 1190,
-    "partySharePercentage": 0.27763584908741795
+    "partySharePercentage": null
   },
   {
     "partyName": "Sinn Féin",
@@ -105,7 +105,7 @@
     "partySeatsNewlyLost": 6,
     "partySeatsChange": -6,
     "partyVotes": 19124,
-    "partySharePercentage": 4.461771410040153
+    "partySharePercentage": null
   },
   {
     "partyName": "SNP",
@@ -114,7 +114,7 @@
     "partySeatsNewlyLost": 32,
     "partySeatsChange": -31,
     "partyVotes": 83134,
-    "partySharePercentage": 19.39578040170874
+    "partySharePercentage": null
   },
   {
     "partyName": "The Speaker",
@@ -123,7 +123,7 @@
     "partySeatsNewlyLost": 1,
     "partySeatsChange": -1,
     "partyVotes": 0,
-    "partySharePercentage": 0
+    "partySharePercentage": null
   },
   {
     "partyName": "Ukip",
@@ -132,7 +132,7 @@
     "partySeatsNewlyLost": 0,
     "partySeatsChange": 0,
     "partyVotes": 0,
-    "partySharePercentage": 0
+    "partySharePercentage": null
   },
   {
     "partyName": "UUP",
@@ -141,6 +141,6 @@
     "partySeatsNewlyLost": 0,
     "partySeatsChange": 0,
     "partyVotes": 0,
-    "partySharePercentage": 0
+    "partySharePercentage": null
   }
 ]

--- a/components/elections/sample-data/utils.js
+++ b/components/elections/sample-data/utils.js
@@ -1,0 +1,17 @@
+/**
+ * @file
+ * Util functions for UK elections sample data
+ */
+
+export const formatResultsData = (data, partiesToShowInTable) => {
+  return data.map(d => ({
+    party: d.partyName,
+    seats: d.partySeats,
+    projectedSeats: d.partySeatsForecast,
+    voteShare: d.partySharePercentage,
+    isInTable: partiesToShowInTable.includes(d.partyName),
+    isOthers: d.partyName === 'Independent/Other',
+  }));
+};
+
+export default null;

--- a/components/elections/seats-bar-chart/index.js
+++ b/components/elections/seats-bar-chart/index.js
@@ -80,8 +80,8 @@ const SeatsBarChart = ({
 
         <thead>
           <tr>
-            {tableHeaders.map(t => (
-              <th key={`th_${t}`}>{t}</th>
+            {tableHeaders.map(tableHeader => (
+              <th key={`th_${tableHeader}`}>{tableHeader}</th>
             ))}
           </tr>
         </thead>
@@ -91,7 +91,7 @@ const SeatsBarChart = ({
             ({ party, seats, seatsCeiling, projectedSeatsOverWon, voteShare, isOthers }) => {
               const { formattedName, shortName, color, whiteOverlayOpacity } = getPartyInfo(party);
               return (
-                <tr className={`row${isOthers ? ' row--others' : ''}`}>
+                <tr className={`row${isOthers ? ' row--others' : ''}`} key={`row_${party}`}>
                   <td className={`party${isOthers ? ' party--others' : ''}`}>
                     <span className="party-badge" style={{ backgroundColor: color }} />
                     <span className="party-bar-container">
@@ -129,7 +129,7 @@ const SeatsBarChart = ({
                     </span>
                   </td>
                   <td className="seats">{seats}</td>
-                  <td className="voteshare">{voteShare.toFixed(1)}</td>
+                  <td className="voteshare">{voteShare ? voteShare.toFixed(1) : '-'}</td>
                 </tr>
               );
             },
@@ -151,6 +151,8 @@ const SeatsBarChart = ({
     </div>
   );
 };
+
+SeatsBarChart.displayName = 'GSeatsBarChart';
 
 SeatsBarChart.propTypes = {
   className: PropTypes.string,

--- a/components/elections/seats-bar-chart/index.js
+++ b/components/elections/seats-bar-chart/index.js
@@ -20,17 +20,26 @@ const SeatsBarChart = ({
   majority,
   showShortPartyNames,
 }) => {
-  const tableData = [
-    ...data
-      .filter(({ isInTable, isOthers }) => isInTable && !isOthers)
-      .sort((a, b) => b.projectedSeats - a.projectedSeats),
-    ...data.filter(({ isOthers }) => isOthers),
-  ];
-  const footnoteData = data
-    .filter(({ isInTable }) => !isInTable)
-    .sort((a, b) => b.projectedSeats - a.projectedSeats);
+  const showProjectedSeats = data.some(({ projectedSeats }) => projectedSeats);
 
-  const maxSeats = tableData.reduce((acc, { projectedSeats }) => Math.max(acc, projectedSeats), 0);
+  const seatsData = data.map(({ seats, projectedSeats, ...d }) => ({
+    seats,
+    projectedSeats,
+    seatsCeiling: projectedSeats || seats,
+    projectedSeatsOverWon: (projectedSeats || seats) - seats,
+    ...d,
+  }));
+
+  const tableData = [
+    ...seatsData
+      .filter(({ isInTable, isOthers }) => isInTable && !isOthers)
+      .sort((a, b) => b.seatsCeiling - a.seatsCeiling),
+    ...seatsData.filter(({ isOthers }) => isOthers),
+  ];
+
+  const footnoteData = data.filter(({ isInTable }) => !isInTable).sort((a, b) => b.seats - a.seats);
+
+  const maxSeats = tableData.reduce((acc, { seatsCeiling }) => Math.max(acc, seatsCeiling), 0);
   const maxValue = Math.max(majority, maxSeats);
   const calcPercentage = seats => (seats / maxValue) * 100;
 
@@ -39,18 +48,20 @@ const SeatsBarChart = ({
       <div className={`${className}__header`}>
         <h3 className={`${className}__title`}>{title}</h3>
 
-        <div className={`${className}__key`}>
-          <span className={`${className}__key-rect`}>
-            <span
-              className={`${className}__key-rect-overlay`}
-              style={{
-                backgroundImage: `repeating-linear-gradient(50deg, transparent, transparent 3px, ${'#fff1e5'} 3px, ${'#fff1e5'} 5px)`,
-              }}
-            />
-          </span>
+        {showProjectedSeats && (
+          <div className={`${className}__key`}>
+            <span className={`${className}__key-rect`}>
+              <span
+                className={`${className}__key-rect-overlay`}
+                style={{
+                  backgroundImage: `repeating-linear-gradient(50deg, transparent, transparent 3px, ${'#fff1e5'} 3px, ${'#fff1e5'} 5px)`,
+                }}
+              />
+            </span>
 
-          <span className={`${className}__key-text`}>{`= ${keyText}`}</span>
-        </div>
+            <span className={`${className}__key-text`}>{`= ${keyText}`}</span>
+          </div>
+        )}
       </div>
 
       <table className={`${className}__table`}>
@@ -76,50 +87,53 @@ const SeatsBarChart = ({
         </thead>
 
         <tbody>
-          {tableData.map(({ party, seats, projectedSeats, voteShare, isOthers }) => {
-            const { formattedName, shortName, color, whiteOverlayOpacity } = getPartyInfo(party);
-            const projectedSeatsOverWon = projectedSeats - seats;
-            return (
-              <tr className={`row${isOthers ? ' row--others' : ''}`}>
-                <td className={`party${isOthers ? ' party--others' : ''}`}>
-                  <span className="party-badge" style={{ backgroundColor: color }} />
-                  <span className="party-bar-container">
-                    <span
-                      className="party-bar"
-                      style={{
-                        backgroundColor: color,
-                        width: `${calcPercentage(projectedSeats)}%`,
-                      }}
-                    />
-                    <span
-                      className="party-bar party-bar--projected"
-                      style={{
-                        backgroundImage: `repeating-linear-gradient(50deg, transparent, transparent 3px, ${'#fff1e5'} 3px, ${'#fff1e5'} 5px)`,
-                        width: `${calcPercentage(projectedSeatsOverWon)}%`,
-                        left: `${calcPercentage(seats)}%`,
-                      }}
-                    />
-                    <span
-                      className="party-bar party-bar--overlay"
-                      style={{
-                        width: `${calcPercentage(projectedSeats)}%`,
-                        backgroundColor:
-                          whiteOverlayOpacity !== undefined
-                            ? `rgba(255, 255, 255, ${whiteOverlayOpacity})`
-                            : 'rgba(255, 255, 255, 0.3)',
-                      }}
-                    />
-                    <span className="party-name party-name--desktop">
-                      {showShortPartyNames ? shortName : formattedName}
+          {tableData.map(
+            ({ party, seats, seatsCeiling, projectedSeatsOverWon, voteShare, isOthers }) => {
+              const { formattedName, shortName, color, whiteOverlayOpacity } = getPartyInfo(party);
+              return (
+                <tr className={`row${isOthers ? ' row--others' : ''}`}>
+                  <td className={`party${isOthers ? ' party--others' : ''}`}>
+                    <span className="party-badge" style={{ backgroundColor: color }} />
+                    <span className="party-bar-container">
+                      <span
+                        className="party-bar"
+                        style={{
+                          backgroundColor: color,
+                          width: `${calcPercentage(seatsCeiling)}%`,
+                        }}
+                      />
+                      {projectedSeatsOverWon !== 0 && (
+                        <span
+                          className="party-bar party-bar--projected"
+                          style={{
+                            backgroundImage: `repeating-linear-gradient(50deg, transparent, transparent 3px, ${'#fff1e5'} 3px, ${'#fff1e5'} 5px)`,
+                            width: `${calcPercentage(projectedSeatsOverWon)}%`,
+                            left: `${calcPercentage(seats)}%`,
+                          }}
+                        />
+                      )}
+                      <span
+                        className="party-bar party-bar--overlay"
+                        style={{
+                          width: `${calcPercentage(seatsCeiling)}%`,
+                          backgroundColor:
+                            whiteOverlayOpacity !== undefined
+                              ? `rgba(255, 255, 255, ${whiteOverlayOpacity})`
+                              : 'rgba(255, 255, 255, 0.3)',
+                        }}
+                      />
+                      <span className="party-name party-name--desktop">
+                        {showShortPartyNames ? shortName : formattedName}
+                      </span>
+                      <span className="party-name party-name--mobile">{shortName}</span>
                     </span>
-                    <span className="party-name party-name--mobile">{shortName}</span>
-                  </span>
-                </td>
-                <td className="seats">{seats}</td>
-                <td className="voteshare">{voteShare.toFixed(1)}</td>
-              </tr>
-            );
-          })}
+                  </td>
+                  <td className="seats">{seats}</td>
+                  <td className="voteshare">{voteShare.toFixed(1)}</td>
+                </tr>
+              );
+            },
+          )}
         </tbody>
       </table>
 

--- a/components/elections/seats-bar-chart/index.stories.mdx
+++ b/components/elections/seats-bar-chart/index.stories.mdx
@@ -1,58 +1,49 @@
 import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
 import '../../../shared/critical-path.scss';
 import SeatsBarChart from './';
+import { formatResultsData } from '../sample-data/utils.js';
+import resultsStart from '../sample-data/results/start.json';
+import resultsMiddle from '../sample-data/results/middle.json';
+import resultsEnd from '../sample-data/results/end.json';
+
+export const partiesToShowInTable = [
+  'Conservative',
+  'Brexit',
+  'Labour',
+  'Liberal Democrats',
+  'Green',
+  'DUP',
+  'Sinn Féin',
+  'SNP',
+];
+
+export const resultsStartFormatted = formatResultsData(resultsStart, partiesToShowInTable);
+export const resultsMiddleFormatted = formatResultsData(resultsMiddle, partiesToShowInTable);
+export const resultsEndFormatted = formatResultsData(resultsEnd, partiesToShowInTable);
 
 <Meta title="Elections|GE2019/Seats Bar Chart" component={SeatsBarChart} />
 
 # Seats Bar Chart component
 
 <Preview>
-  <Story name="Basic">
+  <Story name="Basic (start)">
     <SeatsBarChart
       tableHeaders={['Party', 'Seats', '% of vote']}
-      data={[
-        {
-          party: 'Conservative',
-          seats: 100,
-          projectedSeats: 317,
-          voteShare: 42.4,
-          isInTable: true,
-        },
-        { party: 'Labour', seats: 70, projectedSeats: 262, voteShare: 40, isInTable: true },
-        { party: 'SNP', seats: 10, projectedSeats: 35, voteShare: 3, isInTable: true },
-        {
-          party: 'Liberal Democrats',
-          seats: 8,
-          projectedSeats: 23,
-          voteShare: 7.4,
-          isInTable: true,
-        },
-        {
-          party: 'DUP',
-          seats: 3,
-          projectedSeats: 10,
-          voteShare: 0.7,
-          isInTable: true,
-        },
-        {
-          party: 'Sinn Fein',
-          seats: 3,
-          projectedSeats: 7,
-          voteShare: 0.6,
-          isInTable: true,
-        },
-        { party: 'Brexit', seats: 1, projectedSeats: 1, voteShare: 7, isInTable: true },
-        {
-          party: 'Others',
-          seats: 8,
-          projectedSeats: 30,
-          voteShare: 3,
-          isInTable: true,
-          isOthers: true,
-        },
-        { party: 'Alliance', seats: 1, projectedSeats: 2, voteShare: 0.5, isInTable: false },
-        { party: 'UUP', seats: 1, projectedSeats: 2, voteShare: 0.3, isInTable: false },
-      ]}
+      data={resultsStartFormatted}
+      majority={320}
+    />
+  </Story>
+  <Story name="Basic (middle)">
+    <SeatsBarChart
+      tableHeaders={['Party', 'Seats', '% of vote']}
+      data={resultsMiddleFormatted}
+      majority={320}
+    />
+  </Story>
+  <Story name="Basic (end)">
+    <SeatsBarChart
+      tableHeaders={['Party', 'Seats', '% of vote']}
+      data={resultsEndFormatted}
       majority={320}
     />
   </Story>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10482,17 +10482,6 @@
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
       "dev": true
     },
-    "d3-dsv": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.2.0.tgz",
-      "integrity": "sha512-9yVlqvZcSOMhCYzniHE7EVUws7Fa1zgw+/EAV2BxJoG3ME19V6BQFBwI855XQDsxyOuG7NibqRMTtiF/Qup46g==",
-      "dev": true,
-      "requires": {
-        "commander": "2",
-        "iconv-lite": "0.4",
-        "rw": "1"
-      }
-    },
     "d3-time": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
@@ -23558,12 +23547,6 @@
       "requires": {
         "aproba": "^1.1.1"
       }
-    },
-    "rw": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=",
-      "dev": true
     },
     "rxjs": {
       "version": "6.5.3",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "bower": "^1.8.4",
     "bower-resolve-webpack-plugin": "^1.0.5",
     "css-loader": "^1.0.0",
-    "d3-dsv": "^1.2.0",
     "enhanced-resolve": "^3.4.1",
     "eslint": "^6.1.0",
     "eslint-config-airbnb": "^18.0.1",

--- a/stories/__snapshots__/Storyshots.test.js.snap
+++ b/stories/__snapshots__/Storyshots.test.js.snap
@@ -5335,7 +5335,662 @@ exports[`Storyshots Elections|GE2019/Race Result Indicator Various Permutations 
 </div>
 `;
 
-exports[`Storyshots Elections|GE2019/Seats Bar Chart Basic 1`] = `
+exports[`Storyshots Elections|GE2019/Seats Bar Chart Basic End 1`] = `
+<div
+  className="g-seats-bar-chart"
+>
+  <div
+    className="g-seats-bar-chart__header"
+  >
+    <h3
+      className="g-seats-bar-chart__title"
+    >
+      Number of seats won
+    </h3>
+  </div>
+  <table
+    className="g-seats-bar-chart__table"
+  >
+    <span
+      className="g-seats-bar-chart__majority-line-container"
+    >
+      <span
+        className="g-seats-bar-chart__majority-line"
+        style={
+          Object {
+            "left": "96.3855421686747%",
+          }
+        }
+      />
+      <span
+        className="g-seats-bar-chart__majority-text"
+        style={
+          Object {
+            "left": "96.3855421686747%",
+          }
+        }
+      >
+        Majority
+      </span>
+    </span>
+    <thead>
+      <tr>
+        <th>
+          Party
+        </th>
+        <th>
+          Seats
+        </th>
+        <th>
+          % of vote
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr
+        className="row"
+      >
+        <td
+          className="party"
+        >
+          <span
+            className="party-badge"
+            style={
+              Object {
+                "backgroundColor": "#149adb",
+              }
+            }
+          />
+          <span
+            className="party-bar-container"
+          >
+            <span
+              className="party-bar"
+              style={
+                Object {
+                  "backgroundColor": "#149adb",
+                  "width": "100%",
+                }
+              }
+            />
+            <span
+              className="party-bar party-bar--overlay"
+              style={
+                Object {
+                  "backgroundColor": "rgba(255, 255, 255, 0.2)",
+                  "width": "100%",
+                }
+              }
+            />
+            <span
+              className="party-name party-name--desktop"
+            >
+              Conservative
+            </span>
+            <span
+              className="party-name party-name--mobile"
+            >
+              Con
+            </span>
+          </span>
+        </td>
+        <td
+          className="seats"
+        >
+          332
+        </td>
+        <td
+          className="voteshare"
+        >
+          37.3
+        </td>
+      </tr>
+      <tr
+        className="row"
+      >
+        <td
+          className="party"
+        >
+          <span
+            className="party-badge"
+            style={
+              Object {
+                "backgroundColor": "#cf4d3c",
+              }
+            }
+          />
+          <span
+            className="party-bar-container"
+          >
+            <span
+              className="party-bar"
+              style={
+                Object {
+                  "backgroundColor": "#cf4d3c",
+                  "width": "53.6144578313253%",
+                }
+              }
+            />
+            <span
+              className="party-bar party-bar--overlay"
+              style={
+                Object {
+                  "backgroundColor": "rgba(255, 255, 255, 0.2)",
+                  "width": "53.6144578313253%",
+                }
+              }
+            />
+            <span
+              className="party-name party-name--desktop"
+            >
+              Labour
+            </span>
+            <span
+              className="party-name party-name--mobile"
+            >
+              Lab
+            </span>
+          </span>
+        </td>
+        <td
+          className="seats"
+        >
+          178
+        </td>
+        <td
+          className="voteshare"
+        >
+          29.0
+        </td>
+      </tr>
+      <tr
+        className="row"
+      >
+        <td
+          className="party"
+        >
+          <span
+            className="party-badge"
+            style={
+              Object {
+                "backgroundColor": "#f09000",
+              }
+            }
+          />
+          <span
+            className="party-bar-container"
+          >
+            <span
+              className="party-bar"
+              style={
+                Object {
+                  "backgroundColor": "#f09000",
+                  "width": "17.16867469879518%",
+                }
+              }
+            />
+            <span
+              className="party-bar party-bar--overlay"
+              style={
+                Object {
+                  "backgroundColor": "rgba(255, 255, 255, 0.2)",
+                  "width": "17.16867469879518%",
+                }
+              }
+            />
+            <span
+              className="party-name party-name--desktop"
+            >
+              Liberal Democrats
+            </span>
+            <span
+              className="party-name party-name--mobile"
+            >
+              Lib Dem
+            </span>
+          </span>
+        </td>
+        <td
+          className="seats"
+        >
+          57
+        </td>
+        <td
+          className="voteshare"
+        >
+          15.4
+        </td>
+      </tr>
+      <tr
+        className="row"
+      >
+        <td
+          className="party"
+        >
+          <span
+            className="party-badge"
+            style={
+              Object {
+                "backgroundColor": "#ffdf00",
+              }
+            }
+          />
+          <span
+            className="party-bar-container"
+          >
+            <span
+              className="party-bar"
+              style={
+                Object {
+                  "backgroundColor": "#ffdf00",
+                  "width": "13.55421686746988%",
+                }
+              }
+            />
+            <span
+              className="party-bar party-bar--overlay"
+              style={
+                Object {
+                  "backgroundColor": "rgba(255, 255, 255, 0)",
+                  "width": "13.55421686746988%",
+                }
+              }
+            />
+            <span
+              className="party-name party-name--desktop"
+            >
+              Scottish National party
+            </span>
+            <span
+              className="party-name party-name--mobile"
+            >
+              SNP
+            </span>
+          </span>
+        </td>
+        <td
+          className="seats"
+        >
+          45
+        </td>
+        <td
+          className="voteshare"
+        >
+          4.0
+        </td>
+      </tr>
+      <tr
+        className="row"
+      >
+        <td
+          className="party"
+        >
+          <span
+            className="party-badge"
+            style={
+              Object {
+                "backgroundColor": "#210066",
+              }
+            }
+          />
+          <span
+            className="party-bar-container"
+          >
+            <span
+              className="party-bar"
+              style={
+                Object {
+                  "backgroundColor": "#210066",
+                  "width": "2.108433734939759%",
+                }
+              }
+            />
+            <span
+              className="party-bar party-bar--overlay"
+              style={
+                Object {
+                  "backgroundColor": "rgba(255, 255, 255, 0.5)",
+                  "width": "2.108433734939759%",
+                }
+              }
+            />
+            <span
+              className="party-name party-name--desktop"
+            >
+              Democratic Unionist party
+            </span>
+            <span
+              className="party-name party-name--mobile"
+            >
+              DUP
+            </span>
+          </span>
+        </td>
+        <td
+          className="seats"
+        >
+          7
+        </td>
+        <td
+          className="voteshare"
+        >
+          0.8
+        </td>
+      </tr>
+      <tr
+        className="row"
+      >
+        <td
+          className="party"
+        >
+          <span
+            className="party-badge"
+            style={
+              Object {
+                "backgroundColor": "#006643",
+              }
+            }
+          />
+          <span
+            className="party-bar-container"
+          >
+            <span
+              className="party-bar"
+              style={
+                Object {
+                  "backgroundColor": "#006643",
+                  "width": "2.108433734939759%",
+                }
+              }
+            />
+            <span
+              className="party-bar party-bar--overlay"
+              style={
+                Object {
+                  "backgroundColor": "rgba(255, 255, 255, 0.3)",
+                  "width": "2.108433734939759%",
+                }
+              }
+            />
+            <span
+              className="party-name party-name--desktop"
+            >
+              Sinn Féin
+            </span>
+            <span
+              className="party-name party-name--mobile"
+            >
+              SF
+            </span>
+          </span>
+        </td>
+        <td
+          className="seats"
+        >
+          7
+        </td>
+        <td
+          className="voteshare"
+        >
+          0.8
+        </td>
+      </tr>
+      <tr
+        className="row"
+      >
+        <td
+          className="party"
+        >
+          <span
+            className="party-badge"
+            style={
+              Object {
+                "backgroundColor": "#8deb9d",
+              }
+            }
+          />
+          <span
+            className="party-bar-container"
+          >
+            <span
+              className="party-bar"
+              style={
+                Object {
+                  "backgroundColor": "#8deb9d",
+                  "width": "1.8072289156626504%",
+                }
+              }
+            />
+            <span
+              className="party-bar party-bar--overlay"
+              style={
+                Object {
+                  "backgroundColor": "rgba(255, 255, 255, 0.3)",
+                  "width": "1.8072289156626504%",
+                }
+              }
+            />
+            <span
+              className="party-name party-name--desktop"
+            >
+              Green
+            </span>
+            <span
+              className="party-name party-name--mobile"
+            >
+              Green
+            </span>
+          </span>
+        </td>
+        <td
+          className="seats"
+        >
+          6
+        </td>
+        <td
+          className="voteshare"
+        >
+          5.5
+        </td>
+      </tr>
+      <tr
+        className="row"
+      >
+        <td
+          className="party"
+        >
+          <span
+            className="party-badge"
+            style={
+              Object {
+                "backgroundColor": "#80cfd6",
+              }
+            }
+          />
+          <span
+            className="party-bar-container"
+          >
+            <span
+              className="party-bar"
+              style={
+                Object {
+                  "backgroundColor": "#80cfd6",
+                  "width": "0.9036144578313252%",
+                }
+              }
+            />
+            <span
+              className="party-bar party-bar--overlay"
+              style={
+                Object {
+                  "backgroundColor": "rgba(255, 255, 255, 0.3)",
+                  "width": "0.9036144578313252%",
+                }
+              }
+            />
+            <span
+              className="party-name party-name--desktop"
+            >
+              Brexit party
+            </span>
+            <span
+              className="party-name party-name--mobile"
+            >
+              Brexit
+            </span>
+          </span>
+        </td>
+        <td
+          className="seats"
+        >
+          3
+        </td>
+        <td
+          className="voteshare"
+        >
+          2.8
+        </td>
+      </tr>
+      <tr
+        className="row row--others"
+      >
+        <td
+          className="party party--others"
+        >
+          <span
+            className="party-badge"
+            style={
+              Object {
+                "backgroundColor": "#d9cace",
+              }
+            }
+          />
+          <span
+            className="party-bar-container"
+          >
+            <span
+              className="party-bar"
+              style={
+                Object {
+                  "backgroundColor": "#d9cace",
+                  "width": "0%",
+                }
+              }
+            />
+            <span
+              className="party-bar party-bar--overlay"
+              style={
+                Object {
+                  "backgroundColor": "rgba(255, 255, 255, 0.3)",
+                  "width": "0%",
+                }
+              }
+            />
+            <span
+              className="party-name party-name--desktop"
+            >
+              Independent
+            </span>
+            <span
+              className="party-name party-name--mobile"
+            >
+              Ind
+            </span>
+          </span>
+        </td>
+        <td
+          className="seats"
+        >
+          0
+        </td>
+        <td
+          className="voteshare"
+        >
+          2.0
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <div
+    className="g-seats-bar-chart__footnote"
+  >
+    PC
+     (
+    <span
+      className="seats"
+    >
+      9
+    </span>
+    )
+    , 
+    SDLP
+     (
+    <span
+      className="seats"
+    >
+      3
+    </span>
+    )
+    , 
+    TIGfC
+     (
+    <span
+      className="seats"
+    >
+      1
+    </span>
+    )
+    , 
+    Speaker
+     (
+    <span
+      className="seats"
+    >
+      1
+    </span>
+    )
+    , 
+    UUP
+     (
+    <span
+      className="seats"
+    >
+      1
+    </span>
+    )
+    , 
+    APNI
+     (
+    <span
+      className="seats"
+    >
+      0
+    </span>
+    )
+    , 
+    Ind
+     (
+    <span
+      className="seats"
+    >
+      0
+    </span>
+    )
+    , 
+    Ukip
+     (
+    <span
+      className="seats"
+    >
+      0
+    </span>
+    )
+    
+  </div>
+</div>
+`;
+
+exports[`Storyshots Elections|GE2019/Seats Bar Chart Basic Middle 1`] = `
 <div
   className="g-seats-bar-chart"
 >
@@ -5368,6 +6023,711 @@ exports[`Storyshots Elections|GE2019/Seats Bar Chart Basic 1`] = `
         = PA Projection
       </span>
     </div>
+  </div>
+  <table
+    className="g-seats-bar-chart__table"
+  >
+    <span
+      className="g-seats-bar-chart__majority-line-container"
+    >
+      <span
+        className="g-seats-bar-chart__majority-line"
+        style={
+          Object {
+            "left": "95.52238805970148%",
+          }
+        }
+      />
+      <span
+        className="g-seats-bar-chart__majority-text"
+        style={
+          Object {
+            "left": "95.52238805970148%",
+          }
+        }
+      >
+        Majority
+      </span>
+    </span>
+    <thead>
+      <tr>
+        <th>
+          Party
+        </th>
+        <th>
+          Seats
+        </th>
+        <th>
+          % of vote
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr
+        className="row"
+      >
+        <td
+          className="party"
+        >
+          <span
+            className="party-badge"
+            style={
+              Object {
+                "backgroundColor": "#149adb",
+              }
+            }
+          />
+          <span
+            className="party-bar-container"
+          >
+            <span
+              className="party-bar"
+              style={
+                Object {
+                  "backgroundColor": "#149adb",
+                  "width": "100%",
+                }
+              }
+            />
+            <span
+              className="party-bar party-bar--projected"
+              style={
+                Object {
+                  "backgroundImage": "repeating-linear-gradient(50deg, transparent, transparent 3px, #fff1e5 3px, #fff1e5 5px)",
+                  "left": "54.62686567164179%",
+                  "width": "45.37313432835821%",
+                }
+              }
+            />
+            <span
+              className="party-bar party-bar--overlay"
+              style={
+                Object {
+                  "backgroundColor": "rgba(255, 255, 255, 0.2)",
+                  "width": "100%",
+                }
+              }
+            />
+            <span
+              className="party-name party-name--desktop"
+            >
+              Conservative
+            </span>
+            <span
+              className="party-name party-name--mobile"
+            >
+              Con
+            </span>
+          </span>
+        </td>
+        <td
+          className="seats"
+        >
+          183
+        </td>
+        <td
+          className="voteshare"
+        >
+          37.5
+        </td>
+      </tr>
+      <tr
+        className="row"
+      >
+        <td
+          className="party"
+        >
+          <span
+            className="party-badge"
+            style={
+              Object {
+                "backgroundColor": "#cf4d3c",
+              }
+            }
+          />
+          <span
+            className="party-bar-container"
+          >
+            <span
+              className="party-bar"
+              style={
+                Object {
+                  "backgroundColor": "#cf4d3c",
+                  "width": "55.223880597014926%",
+                }
+              }
+            />
+            <span
+              className="party-bar party-bar--projected"
+              style={
+                Object {
+                  "backgroundImage": "repeating-linear-gradient(50deg, transparent, transparent 3px, #fff1e5 3px, #fff1e5 5px)",
+                  "left": "25.671641791044774%",
+                  "width": "29.55223880597015%",
+                }
+              }
+            />
+            <span
+              className="party-bar party-bar--overlay"
+              style={
+                Object {
+                  "backgroundColor": "rgba(255, 255, 255, 0.2)",
+                  "width": "55.223880597014926%",
+                }
+              }
+            />
+            <span
+              className="party-name party-name--desktop"
+            >
+              Labour
+            </span>
+            <span
+              className="party-name party-name--mobile"
+            >
+              Lab
+            </span>
+          </span>
+        </td>
+        <td
+          className="seats"
+        >
+          86
+        </td>
+        <td
+          className="voteshare"
+        >
+          28.0
+        </td>
+      </tr>
+      <tr
+        className="row"
+      >
+        <td
+          className="party"
+        >
+          <span
+            className="party-badge"
+            style={
+              Object {
+                "backgroundColor": "#ffdf00",
+              }
+            }
+          />
+          <span
+            className="party-bar-container"
+          >
+            <span
+              className="party-bar"
+              style={
+                Object {
+                  "backgroundColor": "#ffdf00",
+                  "width": "14.925373134328357%",
+                }
+              }
+            />
+            <span
+              className="party-bar party-bar--projected"
+              style={
+                Object {
+                  "backgroundImage": "repeating-linear-gradient(50deg, transparent, transparent 3px, #fff1e5 3px, #fff1e5 5px)",
+                  "left": "7.761194029850746%",
+                  "width": "7.164179104477612%",
+                }
+              }
+            />
+            <span
+              className="party-bar party-bar--overlay"
+              style={
+                Object {
+                  "backgroundColor": "rgba(255, 255, 255, 0)",
+                  "width": "14.925373134328357%",
+                }
+              }
+            />
+            <span
+              className="party-name party-name--desktop"
+            >
+              Scottish National party
+            </span>
+            <span
+              className="party-name party-name--mobile"
+            >
+              SNP
+            </span>
+          </span>
+        </td>
+        <td
+          className="seats"
+        >
+          26
+        </td>
+        <td
+          className="voteshare"
+        >
+          4.2
+        </td>
+      </tr>
+      <tr
+        className="row"
+      >
+        <td
+          className="party"
+        >
+          <span
+            className="party-badge"
+            style={
+              Object {
+                "backgroundColor": "#f09000",
+              }
+            }
+          />
+          <span
+            className="party-bar-container"
+          >
+            <span
+              className="party-bar"
+              style={
+                Object {
+                  "backgroundColor": "#f09000",
+                  "width": "14.328358208955224%",
+                }
+              }
+            />
+            <span
+              className="party-bar party-bar--projected"
+              style={
+                Object {
+                  "backgroundImage": "repeating-linear-gradient(50deg, transparent, transparent 3px, #fff1e5 3px, #fff1e5 5px)",
+                  "left": "10.44776119402985%",
+                  "width": "3.880597014925373%",
+                }
+              }
+            />
+            <span
+              className="party-bar party-bar--overlay"
+              style={
+                Object {
+                  "backgroundColor": "rgba(255, 255, 255, 0.2)",
+                  "width": "14.328358208955224%",
+                }
+              }
+            />
+            <span
+              className="party-name party-name--desktop"
+            >
+              Liberal Democrats
+            </span>
+            <span
+              className="party-name party-name--mobile"
+            >
+              Lib Dem
+            </span>
+          </span>
+        </td>
+        <td
+          className="seats"
+        >
+          35
+        </td>
+        <td
+          className="voteshare"
+        >
+          16.2
+        </td>
+      </tr>
+      <tr
+        className="row"
+      >
+        <td
+          className="party"
+        >
+          <span
+            className="party-badge"
+            style={
+              Object {
+                "backgroundColor": "#006643",
+              }
+            }
+          />
+          <span
+            className="party-bar-container"
+          >
+            <span
+              className="party-bar"
+              style={
+                Object {
+                  "backgroundColor": "#006643",
+                  "width": "1.1940298507462688%",
+                }
+              }
+            />
+            <span
+              className="party-bar party-bar--overlay"
+              style={
+                Object {
+                  "backgroundColor": "rgba(255, 255, 255, 0.3)",
+                  "width": "1.1940298507462688%",
+                }
+              }
+            />
+            <span
+              className="party-name party-name--desktop"
+            >
+              Sinn Féin
+            </span>
+            <span
+              className="party-name party-name--mobile"
+            >
+              SF
+            </span>
+          </span>
+        </td>
+        <td
+          className="seats"
+        >
+          4
+        </td>
+        <td
+          className="voteshare"
+        >
+          0.7
+        </td>
+      </tr>
+      <tr
+        className="row"
+      >
+        <td
+          className="party"
+        >
+          <span
+            className="party-badge"
+            style={
+              Object {
+                "backgroundColor": "#210066",
+              }
+            }
+          />
+          <span
+            className="party-bar-container"
+          >
+            <span
+              className="party-bar"
+              style={
+                Object {
+                  "backgroundColor": "#210066",
+                  "width": "0.8955223880597015%",
+                }
+              }
+            />
+            <span
+              className="party-bar party-bar--overlay"
+              style={
+                Object {
+                  "backgroundColor": "rgba(255, 255, 255, 0.5)",
+                  "width": "0.8955223880597015%",
+                }
+              }
+            />
+            <span
+              className="party-name party-name--desktop"
+            >
+              Democratic Unionist party
+            </span>
+            <span
+              className="party-name party-name--mobile"
+            >
+              DUP
+            </span>
+          </span>
+        </td>
+        <td
+          className="seats"
+        >
+          3
+        </td>
+        <td
+          className="voteshare"
+        >
+          0.7
+        </td>
+      </tr>
+      <tr
+        className="row"
+      >
+        <td
+          className="party"
+        >
+          <span
+            className="party-badge"
+            style={
+              Object {
+                "backgroundColor": "#8deb9d",
+              }
+            }
+          />
+          <span
+            className="party-bar-container"
+          >
+            <span
+              className="party-bar"
+              style={
+                Object {
+                  "backgroundColor": "#8deb9d",
+                  "width": "0.8955223880597015%",
+                }
+              }
+            />
+            <span
+              className="party-bar party-bar--projected"
+              style={
+                Object {
+                  "backgroundImage": "repeating-linear-gradient(50deg, transparent, transparent 3px, #fff1e5 3px, #fff1e5 5px)",
+                  "left": "0.5970149253731344%",
+                  "width": "0.2985074626865672%",
+                }
+              }
+            />
+            <span
+              className="party-bar party-bar--overlay"
+              style={
+                Object {
+                  "backgroundColor": "rgba(255, 255, 255, 0.3)",
+                  "width": "0.8955223880597015%",
+                }
+              }
+            />
+            <span
+              className="party-name party-name--desktop"
+            >
+              Green
+            </span>
+            <span
+              className="party-name party-name--mobile"
+            >
+              Green
+            </span>
+          </span>
+        </td>
+        <td
+          className="seats"
+        >
+          2
+        </td>
+        <td
+          className="voteshare"
+        >
+          5.0
+        </td>
+      </tr>
+      <tr
+        className="row"
+      >
+        <td
+          className="party"
+        >
+          <span
+            className="party-badge"
+            style={
+              Object {
+                "backgroundColor": "#80cfd6",
+              }
+            }
+          />
+          <span
+            className="party-bar-container"
+          >
+            <span
+              className="party-bar"
+              style={
+                Object {
+                  "backgroundColor": "#80cfd6",
+                  "width": "0.2985074626865672%",
+                }
+              }
+            />
+            <span
+              className="party-bar party-bar--overlay"
+              style={
+                Object {
+                  "backgroundColor": "rgba(255, 255, 255, 0.3)",
+                  "width": "0.2985074626865672%",
+                }
+              }
+            />
+            <span
+              className="party-name party-name--desktop"
+            >
+              Brexit party
+            </span>
+            <span
+              className="party-name party-name--mobile"
+            >
+              Brexit
+            </span>
+          </span>
+        </td>
+        <td
+          className="seats"
+        >
+          1
+        </td>
+        <td
+          className="voteshare"
+        >
+          3.0
+        </td>
+      </tr>
+      <tr
+        className="row row--others"
+      >
+        <td
+          className="party party--others"
+        >
+          <span
+            className="party-badge"
+            style={
+              Object {
+                "backgroundColor": "#d9cace",
+              }
+            }
+          />
+          <span
+            className="party-bar-container"
+          >
+            <span
+              className="party-bar"
+              style={
+                Object {
+                  "backgroundColor": "#d9cace",
+                  "width": "0.2985074626865672%",
+                }
+              }
+            />
+            <span
+              className="party-bar party-bar--overlay"
+              style={
+                Object {
+                  "backgroundColor": "rgba(255, 255, 255, 0.3)",
+                  "width": "0.2985074626865672%",
+                }
+              }
+            />
+            <span
+              className="party-name party-name--desktop"
+            >
+              Independent
+            </span>
+            <span
+              className="party-name party-name--mobile"
+            >
+              Ind
+            </span>
+          </span>
+        </td>
+        <td
+          className="seats"
+        >
+          1
+        </td>
+        <td
+          className="voteshare"
+        >
+          2.2
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <div
+    className="g-seats-bar-chart__footnote"
+  >
+    PC
+     (
+    <span
+      className="seats"
+    >
+      7
+    </span>
+    )
+    , 
+    TIGfC
+     (
+    <span
+      className="seats"
+    >
+      1
+    </span>
+    )
+    , 
+    Ind
+     (
+    <span
+      className="seats"
+    >
+      1
+    </span>
+    )
+    , 
+    SDLP
+     (
+    <span
+      className="seats"
+    >
+      1
+    </span>
+    )
+    , 
+    Speaker
+     (
+    <span
+      className="seats"
+    >
+      1
+    </span>
+    )
+    , 
+    APNI
+     (
+    <span
+      className="seats"
+    >
+      0
+    </span>
+    )
+    , 
+    Ukip
+     (
+    <span
+      className="seats"
+    >
+      0
+    </span>
+    )
+    , 
+    UUP
+     (
+    <span
+      className="seats"
+    >
+      0
+    </span>
+    )
+    
+  </div>
+</div>
+`;
+
+exports[`Storyshots Elections|GE2019/Seats Bar Chart Basic Start 1`] = `
+<div
+  className="g-seats-bar-chart"
+>
+  <div
+    className="g-seats-bar-chart__header"
+  >
+    <h3
+      className="g-seats-bar-chart__title"
+    >
+      Number of seats won
+    </h3>
   </div>
   <table
     className="g-seats-bar-chart__table"
@@ -5430,17 +6790,7 @@ exports[`Storyshots Elections|GE2019/Seats Bar Chart Basic 1`] = `
               style={
                 Object {
                   "backgroundColor": "#149adb",
-                  "width": "99.0625%",
-                }
-              }
-            />
-            <span
-              className="party-bar party-bar--projected"
-              style={
-                Object {
-                  "backgroundImage": "repeating-linear-gradient(50deg, transparent, transparent 3px, #fff1e5 3px, #fff1e5 5px)",
-                  "left": "31.25%",
-                  "width": "67.8125%",
+                  "width": "1.5625%",
                 }
               }
             />
@@ -5449,7 +6799,7 @@ exports[`Storyshots Elections|GE2019/Seats Bar Chart Basic 1`] = `
               style={
                 Object {
                   "backgroundColor": "rgba(255, 255, 255, 0.2)",
-                  "width": "99.0625%",
+                  "width": "1.5625%",
                 }
               }
             />
@@ -5468,80 +6818,12 @@ exports[`Storyshots Elections|GE2019/Seats Bar Chart Basic 1`] = `
         <td
           className="seats"
         >
-          100
+          5
         </td>
         <td
           className="voteshare"
         >
-          42.4
-        </td>
-      </tr>
-      <tr
-        className="row"
-      >
-        <td
-          className="party"
-        >
-          <span
-            className="party-badge"
-            style={
-              Object {
-                "backgroundColor": "#cf4d3c",
-              }
-            }
-          />
-          <span
-            className="party-bar-container"
-          >
-            <span
-              className="party-bar"
-              style={
-                Object {
-                  "backgroundColor": "#cf4d3c",
-                  "width": "81.875%",
-                }
-              }
-            />
-            <span
-              className="party-bar party-bar--projected"
-              style={
-                Object {
-                  "backgroundImage": "repeating-linear-gradient(50deg, transparent, transparent 3px, #fff1e5 3px, #fff1e5 5px)",
-                  "left": "21.875%",
-                  "width": "60%",
-                }
-              }
-            />
-            <span
-              className="party-bar party-bar--overlay"
-              style={
-                Object {
-                  "backgroundColor": "rgba(255, 255, 255, 0.2)",
-                  "width": "81.875%",
-                }
-              }
-            />
-            <span
-              className="party-name party-name--desktop"
-            >
-              Labour
-            </span>
-            <span
-              className="party-name party-name--mobile"
-            >
-              Lab
-            </span>
-          </span>
-        </td>
-        <td
-          className="seats"
-        >
-          70
-        </td>
-        <td
-          className="voteshare"
-        >
-          40.0
+          -
         </td>
       </tr>
       <tr
@@ -5566,17 +6848,7 @@ exports[`Storyshots Elections|GE2019/Seats Bar Chart Basic 1`] = `
               style={
                 Object {
                   "backgroundColor": "#ffdf00",
-                  "width": "10.9375%",
-                }
-              }
-            />
-            <span
-              className="party-bar party-bar--projected"
-              style={
-                Object {
-                  "backgroundImage": "repeating-linear-gradient(50deg, transparent, transparent 3px, #fff1e5 3px, #fff1e5 5px)",
-                  "left": "3.125%",
-                  "width": "7.8125%",
+                  "width": "1.25%",
                 }
               }
             />
@@ -5585,7 +6857,7 @@ exports[`Storyshots Elections|GE2019/Seats Bar Chart Basic 1`] = `
               style={
                 Object {
                   "backgroundColor": "rgba(255, 255, 255, 0)",
-                  "width": "10.9375%",
+                  "width": "1.25%",
                 }
               }
             />
@@ -5604,12 +6876,70 @@ exports[`Storyshots Elections|GE2019/Seats Bar Chart Basic 1`] = `
         <td
           className="seats"
         >
-          10
+          4
         </td>
         <td
           className="voteshare"
         >
-          3.0
+          -
+        </td>
+      </tr>
+      <tr
+        className="row"
+      >
+        <td
+          className="party"
+        >
+          <span
+            className="party-badge"
+            style={
+              Object {
+                "backgroundColor": "#cf4d3c",
+              }
+            }
+          />
+          <span
+            className="party-bar-container"
+          >
+            <span
+              className="party-bar"
+              style={
+                Object {
+                  "backgroundColor": "#cf4d3c",
+                  "width": "0.3125%",
+                }
+              }
+            />
+            <span
+              className="party-bar party-bar--overlay"
+              style={
+                Object {
+                  "backgroundColor": "rgba(255, 255, 255, 0.2)",
+                  "width": "0.3125%",
+                }
+              }
+            />
+            <span
+              className="party-name party-name--desktop"
+            >
+              Labour
+            </span>
+            <span
+              className="party-name party-name--mobile"
+            >
+              Lab
+            </span>
+          </span>
+        </td>
+        <td
+          className="seats"
+        >
+          1
+        </td>
+        <td
+          className="voteshare"
+        >
+          -
         </td>
       </tr>
       <tr
@@ -5634,17 +6964,7 @@ exports[`Storyshots Elections|GE2019/Seats Bar Chart Basic 1`] = `
               style={
                 Object {
                   "backgroundColor": "#f09000",
-                  "width": "7.187499999999999%",
-                }
-              }
-            />
-            <span
-              className="party-bar party-bar--projected"
-              style={
-                Object {
-                  "backgroundImage": "repeating-linear-gradient(50deg, transparent, transparent 3px, #fff1e5 3px, #fff1e5 5px)",
-                  "left": "2.5%",
-                  "width": "4.6875%",
+                  "width": "0.3125%",
                 }
               }
             />
@@ -5653,7 +6973,7 @@ exports[`Storyshots Elections|GE2019/Seats Bar Chart Basic 1`] = `
               style={
                 Object {
                   "backgroundColor": "rgba(255, 255, 255, 0.2)",
-                  "width": "7.187499999999999%",
+                  "width": "0.3125%",
                 }
               }
             />
@@ -5672,80 +6992,12 @@ exports[`Storyshots Elections|GE2019/Seats Bar Chart Basic 1`] = `
         <td
           className="seats"
         >
-          8
+          1
         </td>
         <td
           className="voteshare"
         >
-          7.4
-        </td>
-      </tr>
-      <tr
-        className="row"
-      >
-        <td
-          className="party"
-        >
-          <span
-            className="party-badge"
-            style={
-              Object {
-                "backgroundColor": "#210066",
-              }
-            }
-          />
-          <span
-            className="party-bar-container"
-          >
-            <span
-              className="party-bar"
-              style={
-                Object {
-                  "backgroundColor": "#210066",
-                  "width": "3.125%",
-                }
-              }
-            />
-            <span
-              className="party-bar party-bar--projected"
-              style={
-                Object {
-                  "backgroundImage": "repeating-linear-gradient(50deg, transparent, transparent 3px, #fff1e5 3px, #fff1e5 5px)",
-                  "left": "0.9375%",
-                  "width": "2.1875%",
-                }
-              }
-            />
-            <span
-              className="party-bar party-bar--overlay"
-              style={
-                Object {
-                  "backgroundColor": "rgba(255, 255, 255, 0.5)",
-                  "width": "3.125%",
-                }
-              }
-            />
-            <span
-              className="party-name party-name--desktop"
-            >
-              Democratic Unionist party
-            </span>
-            <span
-              className="party-name party-name--mobile"
-            >
-              DUP
-            </span>
-          </span>
-        </td>
-        <td
-          className="seats"
-        >
-          3
-        </td>
-        <td
-          className="voteshare"
-        >
-          0.7
+          -
         </td>
       </tr>
       <tr
@@ -5770,17 +7022,7 @@ exports[`Storyshots Elections|GE2019/Seats Bar Chart Basic 1`] = `
               style={
                 Object {
                   "backgroundColor": "#006643",
-                  "width": "2.1875%",
-                }
-              }
-            />
-            <span
-              className="party-bar party-bar--projected"
-              style={
-                Object {
-                  "backgroundImage": "repeating-linear-gradient(50deg, transparent, transparent 3px, #fff1e5 3px, #fff1e5 5px)",
-                  "left": "0.9375%",
-                  "width": "1.25%",
+                  "width": "0.3125%",
                 }
               }
             />
@@ -5789,7 +7031,7 @@ exports[`Storyshots Elections|GE2019/Seats Bar Chart Basic 1`] = `
               style={
                 Object {
                   "backgroundColor": "rgba(255, 255, 255, 0.3)",
-                  "width": "2.1875%",
+                  "width": "0.3125%",
                 }
               }
             />
@@ -5808,12 +7050,12 @@ exports[`Storyshots Elections|GE2019/Seats Bar Chart Basic 1`] = `
         <td
           className="seats"
         >
-          3
+          1
         </td>
         <td
           className="voteshare"
         >
-          0.6
+          -
         </td>
       </tr>
       <tr
@@ -5838,16 +7080,6 @@ exports[`Storyshots Elections|GE2019/Seats Bar Chart Basic 1`] = `
               style={
                 Object {
                   "backgroundColor": "#80cfd6",
-                  "width": "0.3125%",
-                }
-              }
-            />
-            <span
-              className="party-bar party-bar--projected"
-              style={
-                Object {
-                  "backgroundImage": "repeating-linear-gradient(50deg, transparent, transparent 3px, #fff1e5 3px, #fff1e5 5px)",
-                  "left": "0.3125%",
                   "width": "0%",
                 }
               }
@@ -5857,7 +7089,7 @@ exports[`Storyshots Elections|GE2019/Seats Bar Chart Basic 1`] = `
               style={
                 Object {
                   "backgroundColor": "rgba(255, 255, 255, 0.3)",
-                  "width": "0.3125%",
+                  "width": "0%",
                 }
               }
             />
@@ -5876,12 +7108,128 @@ exports[`Storyshots Elections|GE2019/Seats Bar Chart Basic 1`] = `
         <td
           className="seats"
         >
-          1
+          0
         </td>
         <td
           className="voteshare"
         >
-          7.0
+          -
+        </td>
+      </tr>
+      <tr
+        className="row"
+      >
+        <td
+          className="party"
+        >
+          <span
+            className="party-badge"
+            style={
+              Object {
+                "backgroundColor": "#210066",
+              }
+            }
+          />
+          <span
+            className="party-bar-container"
+          >
+            <span
+              className="party-bar"
+              style={
+                Object {
+                  "backgroundColor": "#210066",
+                  "width": "0%",
+                }
+              }
+            />
+            <span
+              className="party-bar party-bar--overlay"
+              style={
+                Object {
+                  "backgroundColor": "rgba(255, 255, 255, 0.5)",
+                  "width": "0%",
+                }
+              }
+            />
+            <span
+              className="party-name party-name--desktop"
+            >
+              Democratic Unionist party
+            </span>
+            <span
+              className="party-name party-name--mobile"
+            >
+              DUP
+            </span>
+          </span>
+        </td>
+        <td
+          className="seats"
+        >
+          0
+        </td>
+        <td
+          className="voteshare"
+        >
+          -
+        </td>
+      </tr>
+      <tr
+        className="row"
+      >
+        <td
+          className="party"
+        >
+          <span
+            className="party-badge"
+            style={
+              Object {
+                "backgroundColor": "#8deb9d",
+              }
+            }
+          />
+          <span
+            className="party-bar-container"
+          >
+            <span
+              className="party-bar"
+              style={
+                Object {
+                  "backgroundColor": "#8deb9d",
+                  "width": "0%",
+                }
+              }
+            />
+            <span
+              className="party-bar party-bar--overlay"
+              style={
+                Object {
+                  "backgroundColor": "rgba(255, 255, 255, 0.3)",
+                  "width": "0%",
+                }
+              }
+            />
+            <span
+              className="party-name party-name--desktop"
+            >
+              Green
+            </span>
+            <span
+              className="party-name party-name--mobile"
+            >
+              Green
+            </span>
+          </span>
+        </td>
+        <td
+          className="seats"
+        >
+          0
+        </td>
+        <td
+          className="voteshare"
+        >
+          -
         </td>
       </tr>
       <tr
@@ -5894,7 +7242,7 @@ exports[`Storyshots Elections|GE2019/Seats Bar Chart Basic 1`] = `
             className="party-badge"
             style={
               Object {
-                "backgroundColor": "#ffffff",
+                "backgroundColor": "#d9cace",
               }
             }
           />
@@ -5905,18 +7253,8 @@ exports[`Storyshots Elections|GE2019/Seats Bar Chart Basic 1`] = `
               className="party-bar"
               style={
                 Object {
-                  "backgroundColor": "#ffffff",
-                  "width": "9.375%",
-                }
-              }
-            />
-            <span
-              className="party-bar party-bar--projected"
-              style={
-                Object {
-                  "backgroundImage": "repeating-linear-gradient(50deg, transparent, transparent 3px, #fff1e5 3px, #fff1e5 5px)",
-                  "left": "2.5%",
-                  "width": "6.875000000000001%",
+                  "backgroundColor": "#d9cace",
+                  "width": "0%",
                 }
               }
             />
@@ -5925,31 +7263,31 @@ exports[`Storyshots Elections|GE2019/Seats Bar Chart Basic 1`] = `
               style={
                 Object {
                   "backgroundColor": "rgba(255, 255, 255, 0.3)",
-                  "width": "9.375%",
+                  "width": "0%",
                 }
               }
             />
             <span
               className="party-name party-name--desktop"
             >
-              Others
+              Independent
             </span>
             <span
               className="party-name party-name--mobile"
             >
-              Others
+              Ind
             </span>
           </span>
         </td>
         <td
           className="seats"
         >
-          8
+          0
         </td>
         <td
           className="voteshare"
         >
-          3.0
+          -
         </td>
       </tr>
     </tbody>
@@ -5962,7 +7300,61 @@ exports[`Storyshots Elections|GE2019/Seats Bar Chart Basic 1`] = `
     <span
       className="seats"
     >
-      1
+      0
+    </span>
+    )
+    , 
+    TIGfC
+     (
+    <span
+      className="seats"
+    >
+      0
+    </span>
+    )
+    , 
+    Ind
+     (
+    <span
+      className="seats"
+    >
+      0
+    </span>
+    )
+    , 
+    PC
+     (
+    <span
+      className="seats"
+    >
+      0
+    </span>
+    )
+    , 
+    SDLP
+     (
+    <span
+      className="seats"
+    >
+      0
+    </span>
+    )
+    , 
+    Speaker
+     (
+    <span
+      className="seats"
+    >
+      0
+    </span>
+    )
+    , 
+    Ukip
+     (
+    <span
+      className="seats"
+    >
+      0
     </span>
     )
     , 
@@ -5971,7 +7363,7 @@ exports[`Storyshots Elections|GE2019/Seats Bar Chart Basic 1`] = `
     <span
       className="seats"
     >
-      1
+      0
     </span>
     )
     


### PR DESCRIPTION
Also removes d3-dsv
Adds example data from beginning, middle and end of election results

Closes https://github.com/Financial-Times/djd-ge2019-results-page/issues/58