### PR TITLE
Stop o-typography overriding autosuggest search styles

### DIFF
--- a/components/autosuggest-search/styles.scss
+++ b/components/autosuggest-search/styles.scss
@@ -47,7 +47,8 @@
     width: 100%;
 
     ul li {
-      font-family: MetricWeb, sans-serif;
+      font-family: MetricWeb, sans-serif !important;
+      line-height: normal !important;
     }
 
     ul li:before {
@@ -59,7 +60,6 @@
     font-family: MetricWeb, sans-serif;
     font-size: 16px;
     line-height: 24px;
-    text-transform: uppercase;
     color: #33302e;
     background-color: #ffffff;
     margin-top: 0;


### PR DESCRIPTION
Closes https://github.com/Financial-Times/djd-ge2019-results-page/issues/138