### PR TITLE
Fix net change 0 label in empty state

### DIFF
--- a/components/elections/net-change-bar-chart/index.js
+++ b/components/elections/net-change-bar-chart/index.js
@@ -72,7 +72,11 @@ const NetChangeBarChart = ({ className, title, tableHeaders, data, showShortPart
                 </td>
                 <td
                   className={`bar-change${isOthers ? ' bar-change--others' : ''}${
-                    seatChange < 0 ? ' bar-change--others--negative' : ''
+                    seatChange < 0
+                      ? ' bar-change--others--negative'
+                      : seatChange === 0
+                      ? ' bar-change--others--zero'
+                      : ''
                   }`}
                 >
                   <span className="bar-container">

--- a/components/elections/net-change-bar-chart/index.stories.mdx
+++ b/components/elections/net-change-bar-chart/index.stories.mdx
@@ -6,6 +6,8 @@ import NetChangeBarChart from './';
 
 # Net Change Bar Chart component
 
+# Basic
+
 <Preview>
   <Story name="Basic">
     <NetChangeBarChart
@@ -41,6 +43,48 @@ import NetChangeBarChart from './';
         },
         { party: 'Alliance', seatChange: 2, isInTable: false, isOthers: true },
         { party: 'UUP', seatChange: 1, isInTable: false, isOthers: true },
+      ]}
+    />
+  </Story>
+</Preview>
+
+### Empty state
+
+<Preview>
+  <Story name="Empty state">
+    <NetChangeBarChart
+      tableHeaders={['Party', '0', '+/-']}
+      data={[
+        {
+          party: 'Conservative',
+          seatChange: 0,
+          isInTable: true,
+        },
+        { party: 'Labour', seatChange: 0, isInTable: true },
+        { party: 'SNP', seatChange: 0, isInTable: true },
+        {
+          party: 'Liberal Democrats',
+          seatChange: 0,
+          isInTable: true,
+        },
+        {
+          party: 'DUP',
+          seatChange: 0,
+          isInTable: true,
+        },
+        {
+          party: 'Sinn Fein',
+          seatChange: 0,
+          isInTable: true,
+        },
+        {
+          party: 'Independent/Others',
+          seatChange: 0,
+          isInTable: true,
+          isOthers: true,
+        },
+        { party: 'Alliance', seatChange: 0, isInTable: false, isOthers: true },
+        { party: 'UUP', seatChange: 0, isInTable: false, isOthers: true },
       ]}
     />
   </Story>

--- a/components/elections/net-change-bar-chart/styles.scss
+++ b/components/elections/net-change-bar-chart/styles.scss
@@ -88,7 +88,7 @@
       }
 
       &:nth-child(n + 2) {
-        text-align: right;
+        text-align: center;
       }
 
       &.bar-change {

--- a/components/elections/net-change-bar-chart/styles.scss
+++ b/components/elections/net-change-bar-chart/styles.scss
@@ -110,6 +110,12 @@
           }
         }
 
+        &--others--zero {
+          .bar {
+            border: none;
+          }
+        }
+
         .bar-container {
           display: inline-block;
           width: 100%;

--- a/stories/__snapshots__/Storyshots.test.js.snap
+++ b/stories/__snapshots__/Storyshots.test.js.snap
@@ -7843,6 +7843,542 @@ exports[`Storyshots Elections|GE2019/Net Change Bar Chart Basic 1`] = `
 </div>
 `;
 
+exports[`Storyshots Elections|GE2019/Net Change Bar Chart Empty State 1`] = `
+<div
+  className="g-net-change-bar-chart"
+>
+  <div
+    className="g-net-change-bar-chart__header"
+  >
+    <h3
+      className="g-net-change-bar-chart__title"
+    >
+      Net change in seats compared to outgoing parliament
+    </h3>
+  </div>
+  <table
+    className="g-net-change-bar-chart__table"
+  >
+    <thead>
+      <tr>
+        <th>
+          Party
+        </th>
+        <th
+          className="axis-label"
+        >
+          <span
+            style={
+              Object {
+                "left": "NaN%",
+              }
+            }
+          >
+            0
+          </span>
+        </th>
+        <th>
+          +/-
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr
+        className="row"
+      >
+        <td
+          className="party"
+        >
+          <span
+            className="party-badge"
+            style={
+              Object {
+                "backgroundColor": "#149adb",
+              }
+            }
+          />
+          <span
+            className="party-name party-name--desktop"
+          >
+            Conservative
+          </span>
+          <span
+            className="party-name party-name--mobile"
+          >
+            Con
+          </span>
+        </td>
+        <td
+          className="bar-change bar-change--others--zero"
+        >
+          <span
+            className="bar-container"
+          >
+            <span
+              className="bar"
+              style={
+                Object {
+                  "backgroundColor": "#149adb",
+                  "left": "NaN%",
+                  "width": "NaN%",
+                }
+              }
+            />
+            <span
+              className="bar bar--overlay"
+              style={
+                Object {
+                  "backgroundColor": "rgba(255, 255, 255, 0.2)",
+                  "left": "NaN%",
+                  "width": "NaN%",
+                }
+              }
+            />
+            <span
+              className="centre-line"
+              style={
+                Object {
+                  "left": "NaN%",
+                }
+              }
+            />
+          </span>
+        </td>
+        <td
+          className="change"
+        >
+          0
+        </td>
+      </tr>
+      <tr
+        className="row"
+      >
+        <td
+          className="party"
+        >
+          <span
+            className="party-badge"
+            style={
+              Object {
+                "backgroundColor": "#cf4d3c",
+              }
+            }
+          />
+          <span
+            className="party-name party-name--desktop"
+          >
+            Labour
+          </span>
+          <span
+            className="party-name party-name--mobile"
+          >
+            Lab
+          </span>
+        </td>
+        <td
+          className="bar-change bar-change--others--zero"
+        >
+          <span
+            className="bar-container"
+          >
+            <span
+              className="bar"
+              style={
+                Object {
+                  "backgroundColor": "#cf4d3c",
+                  "left": "NaN%",
+                  "width": "NaN%",
+                }
+              }
+            />
+            <span
+              className="bar bar--overlay"
+              style={
+                Object {
+                  "backgroundColor": "rgba(255, 255, 255, 0.2)",
+                  "left": "NaN%",
+                  "width": "NaN%",
+                }
+              }
+            />
+            <span
+              className="centre-line"
+              style={
+                Object {
+                  "left": "NaN%",
+                }
+              }
+            />
+          </span>
+        </td>
+        <td
+          className="change"
+        >
+          0
+        </td>
+      </tr>
+      <tr
+        className="row"
+      >
+        <td
+          className="party"
+        >
+          <span
+            className="party-badge"
+            style={
+              Object {
+                "backgroundColor": "#ffdf00",
+              }
+            }
+          />
+          <span
+            className="party-name party-name--desktop"
+          >
+            Scottish National party
+          </span>
+          <span
+            className="party-name party-name--mobile"
+          >
+            SNP
+          </span>
+        </td>
+        <td
+          className="bar-change bar-change--others--zero"
+        >
+          <span
+            className="bar-container"
+          >
+            <span
+              className="bar"
+              style={
+                Object {
+                  "backgroundColor": "#ffdf00",
+                  "left": "NaN%",
+                  "width": "NaN%",
+                }
+              }
+            />
+            <span
+              className="bar bar--overlay"
+              style={
+                Object {
+                  "backgroundColor": "rgba(255, 255, 255, 0)",
+                  "left": "NaN%",
+                  "width": "NaN%",
+                }
+              }
+            />
+            <span
+              className="centre-line"
+              style={
+                Object {
+                  "left": "NaN%",
+                }
+              }
+            />
+          </span>
+        </td>
+        <td
+          className="change"
+        >
+          0
+        </td>
+      </tr>
+      <tr
+        className="row"
+      >
+        <td
+          className="party"
+        >
+          <span
+            className="party-badge"
+            style={
+              Object {
+                "backgroundColor": "#f09000",
+              }
+            }
+          />
+          <span
+            className="party-name party-name--desktop"
+          >
+            Liberal Democrats
+          </span>
+          <span
+            className="party-name party-name--mobile"
+          >
+            Lib Dem
+          </span>
+        </td>
+        <td
+          className="bar-change bar-change--others--zero"
+        >
+          <span
+            className="bar-container"
+          >
+            <span
+              className="bar"
+              style={
+                Object {
+                  "backgroundColor": "#f09000",
+                  "left": "NaN%",
+                  "width": "NaN%",
+                }
+              }
+            />
+            <span
+              className="bar bar--overlay"
+              style={
+                Object {
+                  "backgroundColor": "rgba(255, 255, 255, 0.2)",
+                  "left": "NaN%",
+                  "width": "NaN%",
+                }
+              }
+            />
+            <span
+              className="centre-line"
+              style={
+                Object {
+                  "left": "NaN%",
+                }
+              }
+            />
+          </span>
+        </td>
+        <td
+          className="change"
+        >
+          0
+        </td>
+      </tr>
+      <tr
+        className="row"
+      >
+        <td
+          className="party"
+        >
+          <span
+            className="party-badge"
+            style={
+              Object {
+                "backgroundColor": "#210066",
+              }
+            }
+          />
+          <span
+            className="party-name party-name--desktop"
+          >
+            Democratic Unionist party
+          </span>
+          <span
+            className="party-name party-name--mobile"
+          >
+            DUP
+          </span>
+        </td>
+        <td
+          className="bar-change bar-change--others--zero"
+        >
+          <span
+            className="bar-container"
+          >
+            <span
+              className="bar"
+              style={
+                Object {
+                  "backgroundColor": "#210066",
+                  "left": "NaN%",
+                  "width": "NaN%",
+                }
+              }
+            />
+            <span
+              className="bar bar--overlay"
+              style={
+                Object {
+                  "backgroundColor": "rgba(255, 255, 255, 0.5)",
+                  "left": "NaN%",
+                  "width": "NaN%",
+                }
+              }
+            />
+            <span
+              className="centre-line"
+              style={
+                Object {
+                  "left": "NaN%",
+                }
+              }
+            />
+          </span>
+        </td>
+        <td
+          className="change"
+        >
+          0
+        </td>
+      </tr>
+      <tr
+        className="row"
+      >
+        <td
+          className="party"
+        >
+          <span
+            className="party-badge"
+            style={
+              Object {
+                "backgroundColor": "#006643",
+              }
+            }
+          />
+          <span
+            className="party-name party-name--desktop"
+          >
+            Sinn Féin
+          </span>
+          <span
+            className="party-name party-name--mobile"
+          >
+            SF
+          </span>
+        </td>
+        <td
+          className="bar-change bar-change--others--zero"
+        >
+          <span
+            className="bar-container"
+          >
+            <span
+              className="bar"
+              style={
+                Object {
+                  "backgroundColor": "#006643",
+                  "left": "NaN%",
+                  "width": "NaN%",
+                }
+              }
+            />
+            <span
+              className="bar bar--overlay"
+              style={
+                Object {
+                  "backgroundColor": "rgba(255, 255, 255, 0.3)",
+                  "left": "NaN%",
+                  "width": "NaN%",
+                }
+              }
+            />
+            <span
+              className="centre-line"
+              style={
+                Object {
+                  "left": "NaN%",
+                }
+              }
+            />
+          </span>
+        </td>
+        <td
+          className="change"
+        >
+          0
+        </td>
+      </tr>
+      <tr
+        className="row row--others"
+      >
+        <td
+          className="party party--others"
+        >
+          <span
+            className="party-badge"
+            style={
+              Object {
+                "backgroundColor": "#ffffff",
+              }
+            }
+          />
+          <span
+            className="party-name party-name--desktop"
+          >
+            Others
+          </span>
+          <span
+            className="party-name party-name--mobile"
+          >
+            Others
+          </span>
+        </td>
+        <td
+          className="bar-change bar-change--others bar-change--others--zero"
+        >
+          <span
+            className="bar-container"
+          >
+            <span
+              className="bar"
+              style={
+                Object {
+                  "backgroundColor": "#ffffff",
+                  "left": "NaN%",
+                  "width": "NaN%",
+                }
+              }
+            />
+            <span
+              className="bar bar--overlay"
+              style={
+                Object {
+                  "backgroundColor": "rgba(255, 255, 255, 0.3)",
+                  "left": "NaN%",
+                  "width": "NaN%",
+                }
+              }
+            />
+            <span
+              className="centre-line"
+              style={
+                Object {
+                  "left": "NaN%",
+                }
+              }
+            />
+          </span>
+        </td>
+        <td
+          className="change"
+        >
+          0
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <div
+    className="g-net-change-bar-chart__footnote"
+  >
+    APNI
+     (
+    <span
+      className="seats"
+    >
+      0
+    </span>
+    )
+    , 
+    UUP
+     (
+    <span
+      className="seats"
+    >
+      0
+    </span>
+    )
+    
+  </div>
+</div>
+`;
+
 exports[`Storyshots Elections|GE2019/Race Result Indicator Scottish National Party Will Always Be Snp 1`] = `
 <div
   style={


### PR DESCRIPTION
Fixes https://github.com/Financial-Times/djd-ge2019-results-page/issues/240

Fixes two things: 

- fix net change 0 label in empty state
- when "Others" bar is 0, don't show any borders