### PR TITLE
Fixes issue where byline urls were not rendering in correct order

### DIFF
--- a/components/article-head/byline.js
+++ b/components/article-head/byline.js
@@ -25,17 +25,17 @@ const NamesElement = ({ namesList }) =>
     const separator = i === 0 ? '' : i === namesList.length - 1 ? ' and ' : ', ';
     const location = name.location && <Fragment> {name.location}</Fragment>;
     const author = name.url ? (
-      <Fragment key={`author-${name.name}`}>
+      <span key={`author-${name.name}`}>
         <a href={name.url} className="o-typography-author">
           {name.name}
         </a>
         {location}
-      </Fragment>
+      </span>
     ) : (
-      <Fragment key={`author-${name.name}`}>
+      <span key={`author-${name.name}`}>
         <span>{name.name}</span>
         {location}
-      </Fragment>
+      </span>
     );
     return a.concat(separator, author);
   }, []);


### PR DESCRIPTION
This issue only appears on build when using react-snap (see urls in https://ig.ft.com/repo-rate/ vs https://github.com/Financial-Times/ig-repo-rate-story/blob/master/config/article.js#L53). Fragments with keys seem to be the problem