### PR TITLE
Update footer links

### DIFF
--- a/components/footer/index.js
+++ b/components/footer/index.js
@@ -25,153 +25,70 @@ const Footer = () => {
     >
       <div className="o-footer__container">
         <div className="o-footer__row">
-          <nav className="o-footer__matrix" aria-label="Useful links">
+          <nav className="o-footer__matrix" role="navigation" aria-label="Useful links">
             <div className="o-footer__matrix-group o-footer__matrix-group--1">
-              <div className="o-footer__matrix-title">Support</div>
+              <h3 className="o-footer__matrix-title">Support</h3>
               <div className="o-footer__matrix-content" id="o-footer-section-0">
-                <div className="o-footer__matrix-column">
-                  <a className="o-footer__matrix-link" href="//www.ft.com/help">
-                    Help
-                  </a>
-                  <a className="o-footer__matrix-link" href="//www.ft.com/aboutus">
-                    About Us
-                  </a>
+                <div class="o-footer__matrix-column">
+                  <a class="o-footer__matrix-link" href="/tour" data-trackable="View Site Tips">View Site Tips</a>
+                  <a class="o-footer__matrix-link" href="http://help.ft.com" data-trackable="Help Centre">Help Centre</a>
+                  <a class="o-footer__matrix-link" href="http://www.ft.com/aboutus" data-trackable="About Us">About Us</a>
+                  <a class="o-footer__matrix-link" href="/accessibility" data-trackable="Accessibility">Accessibility</a>
+                  <a class="o-footer__matrix-link" href="/tour/myft" data-trackable="myFT Tour">myFT Tour</a>
+                  <a class="o-footer__matrix-link" href="https://aboutus.ft.com/en-gb/careers/" data-trackable="Careers">Careers</a>
                 </div>
               </div>
             </div>
             <div className="o-footer__matrix-group o-footer__matrix-group--1">
-              <div className="o-footer__matrix-title">Legal &amp; Privacy</div>
+              <h3 className="o-footer__matrix-title">Legal &amp; Privacy</h3>
               <div className="o-footer__matrix-content" id="o-footer-section-1">
-                <div className="o-footer__matrix-column">
-                  <a className="o-footer__matrix-link" href="//www.ft.com/servicestools/help/terms">
-                    Terms &amp; Conditions
-                  </a>
-                  <a
-                    className="o-footer__matrix-link"
-                    href="//www.ft.com/servicestools/help/privacy"
-                  >
-                    Privacy
-                  </a>
-                  <a className="o-footer__matrix-link" href="//www.ft.com/cookiepolicy">
-                    Cookies
-                  </a>
-                  <a
-                    className="o-footer__matrix-link"
-                    href="//www.ft.com/servicestools/help/copyright"
-                  >
-                    Copyright
-                  </a>
+                <div class="o-footer__matrix-column">
+                  <a class="o-footer__matrix-link" href="http://help.ft.com/help/legal-privacy/terms-conditions/" data-trackable="Terms &amp; Conditions">Terms &amp; Conditions</a>
+                  <a class="o-footer__matrix-link" href="http://help.ft.com/help/legal-privacy/privacy/" data-trackable="Privacy">Privacy</a>
+                  <a class="o-footer__matrix-link" href="http://help.ft.com/help/legal-privacy/cookies/" data-trackable="Cookies">Cookies</a>
+                  <a class="o-footer__matrix-link" href="http://help.ft.com/help/legal-privacy/copyright/copyright-policy/" data-trackable="Copyright">Copyright</a>
+                  <a class="o-footer__matrix-link" href="https://help.ft.com/help/legal/slavery-statement/" data-trackable="Slavery Statement &amp; Policies">Slavery Statement &amp; Policies</a>
                 </div>
               </div>
             </div>
             <div className="o-footer__matrix-group o-footer__matrix-group--2">
-              <div className="o-footer__matrix-title" aria-controls="o-footer-section-2">
-                Services
-              </div>
+              <h3 className="o-footer__matrix-title" aria-controls="o-footer-section-2">Services</h3>
               <div className="o-footer__matrix-content" id="o-footer-section-2">
-                <div className="o-footer__matrix-column">
-                  <a className="o-footer__matrix-link" href="//sub.ft.com/spa_5">
-                    Individual Subscriptions
-                  </a>
-                  <a
-                    className="o-footer__matrix-link"
-                    href="//enterprise.ft.com/en-gb/services/group-subscriptions/"
-                  >
-                    Group Subscriptions
-                  </a>
-                  <a
-                    className="o-footer__matrix-link"
-                    href="//enterprise.ft.com/en-gb/services/republishing/"
-                  >
-                    Republishing
-                  </a>
-                  <a
-                    className="o-footer__matrix-link"
-                    href="//www.businessesforsale.com/ft2/notices"
-                  >
-                    Contracts &amp; Tenders
-                  </a>
-                  <a
-                    className="o-footer__matrix-link"
-                    href="//commerce.uk.reuters.com/purchase/mostPopular.do?rpc&amp;#x3D;471"
-                  >
-                    Analysts Research
-                  </a>
+                <div class="o-footer__matrix-column">
+                  <a class="o-footer__matrix-link" href="http://live.ft.com/" data-trackable="FT Live">FT Live</a>
+                  <a class="o-footer__matrix-link" href="/securedrop" data-trackable="Share News Tips Securely" data-o-tracking-do-not-track="true">Share News Tips Securely</a>
+                  <a class="o-footer__matrix-link" href="http://www.ft.com/products" data-trackable="Individual Subscriptions">Individual Subscriptions</a>
+                  <a class="o-footer__matrix-link" href="https://enterprise.ft.com/en-gb/services/group-subscriptions/group-contact-us/?segmentId=383c7f63-abf4-b62d-cb33-4c278e6fdf61&amp;cpccampaign=B2B_link_ft.com_footer" data-trackable="Group Subscriptions">Group Subscriptions</a>
+                  <a class="o-footer__matrix-link" href="https://enterprise.ft.com/en-gb/services/republishing/" data-trackable="Republishing">Republishing</a>
+                  <a class="o-footer__matrix-link" href="http://www.businessesforsale.com/ft2/notices" data-trackable="Contracts &amp; Tenders">Contracts &amp; Tenders</a>
                 </div>
-                <div className="o-footer__matrix-column">
-                  <a className="o-footer__matrix-link" href="//www.exec-appointments.com/">
-                    Executive Job Search
-                  </a>
-                  <a
-                    className="o-footer__matrix-link"
-                    aria-label="Advertise with the F T"
-                    href="//fttoolkit.co.uk/d/"
-                  >
-                    Advertise with the FT
-                  </a>
-                  <a
-                    className="o-footer__matrix-link"
-                    aria-label="Follow the F T on Twitter"
-                    href="//twitter.com/ft"
-                  >
-                    Follow the FT on Twitter
-                  </a>
+                <div class="o-footer__matrix-column">
+                  <a class="o-footer__matrix-link" href="https://www.exec-appointments.com/" data-trackable="Executive Job Search">Executive Job Search</a>
+                  <a class="o-footer__matrix-link" href="http://fttoolkit.co.uk/" data-trackable="Advertise with the FT">Advertise with the FT</a>
+                  <a class="o-footer__matrix-link" href="https://twitter.com/financialtimes" data-trackable="Follow the FT on Twitter">Follow the FT on Twitter</a>
+                  <a class="o-footer__matrix-link" href="https://transact.ft.com/en-gb/" data-trackable="FT Transact">FT Transact</a>
+                  <a class="o-footer__matrix-link" href="https://enterprise.ft.com/en-gb/services/group-subscriptions/education/" data-trackable="Secondary Schools">Secondary Schools</a>
                 </div>
               </div>
             </div>
             <div className="o-footer__matrix-group o-footer__matrix-group--2">
-              <div className="o-footer__matrix-title" aria-controls="o-footer-section-3">
-                Tools
-              </div>
+              <h3 className="o-footer__matrix-title" aria-controls="o-footer-section-3">Tools</h3>
               <div className="o-footer__matrix-content" id="o-footer-section-3">
-                <div className="o-footer__matrix-column">
-                  <a
-                    className="o-footer__matrix-link"
-                    href="//markets.ft.com/data/portfolio/dashboard"
-                  >
-                    Portfolio
-                  </a>
-                  <a className="o-footer__matrix-link" href="//ftepaper.ft.com">
-                    Today&apos;s Paper
-                  </a>
-                  <a className="o-footer__matrix-link" href="//markets.ft.com/data/alerts/">
-                    Alerts Hub
-                  </a>
-                  <a
-                    className="o-footer__matrix-link"
-                    href="//rankings.ft.com/businessschoolrankings/global-mba-ranking-2016"
-                  >
-                    MBA Rankings
-                  </a>
+                <div class="o-footer__matrix-column">
+                  <a class="o-footer__matrix-link" href="https://markets.ft.com/data/portfolio/dashboard" data-trackable="Portfolio">Portfolio</a>
+                  <a class="o-footer__matrix-link" href="https://www.ft.com/todaysnewspaper" data-trackable="Today's Newspaper (ePaper)">Today's Newspaper (ePaper)</a>
+                  <a class="o-footer__matrix-link" href="http://markets.ft.com/data/alerts/" data-trackable="Alerts Hub">Alerts Hub</a>
+                  <a class="o-footer__matrix-link" href="http://rankings.ft.com/businessschoolrankings/global-mba-ranking-2019" data-trackable="MBA Rankings">MBA Rankings</a>
                 </div>
-                <div className="o-footer__matrix-column">
-                  <a
-                    className="o-footer__matrix-link"
-                    href="//markets.ft.com/Research/Economic-Calendar"
-                  >
-                    Economic Calendar
-                  </a>
-                  <a className="o-footer__matrix-link" href="//nbe.ft.com/nbe/profile.cfm">
-                    Newsletters
-                  </a>
-                  <a
-                    className="o-footer__matrix-link"
-                    href="//markets.ft.com/research/Markets/Currencies?segid&amp;#x3D;70113"
-                  >
-                    Currency Converter
-                  </a>
-                  <a
-                    className="o-footer__matrix-link"
-                    aria-label="E-books"
-                    href="//www.ft.com/ebooks"
-                  >
-                    Ebooks
-                  </a>
+                <div class="o-footer__matrix-column">
+                  <a class="o-footer__matrix-link" href="https://kat.ft.com/" data-trackable="Enterprise Tools">Enterprise Tools</a>
+                  <a class="o-footer__matrix-link" href="/news-feed" data-trackable="News feed">News feed</a>
+                  <a class="o-footer__matrix-link" href="/newsletters" data-trackable="Newsletters">Newsletters</a>
+                  <a class="o-footer__matrix-link" href="https://markets.ft.com/research/Markets/Currencies?segid=70113" data-trackable="Currency Converter">Currency Converter</a>
                 </div>
               </div>
             </div>
           </nav>
-
           <div className="o-footer__external-link o-footer__matrix-title">
             <a
               className="o-footer__more-from-ft o-footer__matrix-title"
@@ -181,7 +98,6 @@ const Footer = () => {
             </a>
           </div>
         </div>
-
         <div className="o-footer__copyright" role="contentinfo">
           <small>
             Markets data delayed by at least 15 minutes. &#xA9; THE FINANCIAL TIMES LTD{' '}


### PR DESCRIPTION
The main site seems to have changed the set of links in the footer over time, so ours have got out of sync. This updates them to be the same. Also some other minor changes to mirror ft.com.