### PR TITLE
Update last updated with optional dot

### DIFF
--- a/src/last-updated/index.js
+++ b/src/last-updated/index.js
@@ -8,12 +8,12 @@ import PropTypes from 'prop-types';
 import DateTime from '../datetime';
 import './styles.scss';
 
-const LastUpdated = ({ date, live, throbbing }) => (
+const LastUpdated = ({ live, dot, date }) => (
   <div className={`last-updated${live ? ' last-updated--live' : ''}`}>
     {live ? (
       <div className="o-teaser o-teaser--small" data-o-component="o-teaser">
         <div className="o-teaser__content">
-          {throbbing && (
+          {dot && (
             <div
               className="o-teaser__timestamp o-teaser__timestamp--inprogress"
               style={{ display: 'inline-block' }}
@@ -32,7 +32,7 @@ const LastUpdated = ({ date, live, throbbing }) => (
       </div>
     ) : (
       <div>
-        {throbbing && (
+        {dot && (
           <div
             className="o-teaser__timestamp"
             style={{ display: 'inline-block' }}
@@ -49,13 +49,15 @@ const LastUpdated = ({ date, live, throbbing }) => (
 );
 
 LastUpdated.propTypes = {
-  date: PropTypes.instanceOf(Date),
   live: PropTypes.bool,
+  dot: PropTypes.bool,
+  date: PropTypes.instanceOf(Date),
 };
 
 LastUpdated.defaultProps = {
-  date: false,
   live: false,
+  dot: false,
+  date: false,
 };
 
 export default LastUpdated;

--- a/src/last-updated/index.js
+++ b/src/last-updated/index.js
@@ -8,20 +8,22 @@ import PropTypes from 'prop-types';
 import DateTime from '../datetime';
 import './styles.scss';
 
-const LastUpdated = ({ lastUpdated, live }) => (
+const LastUpdated = ({ date, live, throbbing }) => (
   <div className={`last-updated${live ? ' last-updated--live' : ''}`}>
     {live ? (
       <div className="o-teaser o-teaser--small" data-o-component="o-teaser">
         <div className="o-teaser__content">
-          <div
-            className="o-teaser__timestamp o-teaser__timestamp--inprogress"
-            style={{ display: 'inline-block' }}
-          >
-            <span className="o-teaser__timestamp-prefix" />
-          </div>
-          {lastUpdated ? (
+          {throbbing && (
+            <div
+              className="o-teaser__timestamp o-teaser__timestamp--inprogress"
+              style={{ display: 'inline-block' }}
+            >
+              <span className="o-teaser__timestamp-prefix" />
+            </div>
+          )}
+          {date ? (
             <React.Fragment>
-              Last updated <DateTime datestamp={lastUpdated} />
+              Last updated <DateTime datestamp={date} />
             </React.Fragment>
           ) : (
             'Live'
@@ -29,22 +31,31 @@ const LastUpdated = ({ lastUpdated, live }) => (
         </div>
       </div>
     ) : (
-      lastUpdated && (
-        <span>
-          Last updated <DateTime datestamp={lastUpdated} />
-        </span>
-      )
+      <div>
+        {throbbing && (
+          <div
+            className="o-teaser__timestamp"
+            style={{ display: 'inline-block' }}
+          >
+            <span className="o-teaser__timestamp-prefix" />
+          </div>
+        )}
+        {date && (
+          <span>Last updated <DateTime datestamp={date} /></span>
+        )}
+      </div>
     )}
   </div>
 );
 
 LastUpdated.propTypes = {
-  lastUpdated: PropTypes.instanceOf(Date),
+  date: PropTypes.instanceOf(Date),
   live: PropTypes.bool,
 };
+
 LastUpdated.defaultProps = {
-  lastUpdated: false,
-  live: true,
+  date: false,
+  live: false,
 };
 
 export default LastUpdated;

--- a/src/last-updated/index.stories.mdx
+++ b/src/last-updated/index.stories.mdx
@@ -11,19 +11,19 @@ import LastUpdated from './';
   </Story>
 </Preview>
 
-With throbber:
+With dot:
 
 <Preview>
-  <Story name="Standard, throbbing">
-    <LastUpdated throbbing date={new Date('1987-01-05T00:00:00.00')} />
+  <Story name="Standard, dot">
+    <LastUpdated dot date={new Date('1987-01-05T00:00:00.00')} />
   </Story>
 </Preview>
 
-Only throbber:
+Only dot:
 
 <Preview>
-  <Story name="Standard, throbbing without date">
-    <LastUpdated throbbing />
+  <Story name="Standard, dot without date">
+    <LastUpdated dot />
   </Story>
 </Preview>
 
@@ -44,19 +44,19 @@ The live version has a red background:
   </Story>
 </Preview>
 
-Live, with throbber:
+Live, with dot:
 
 <Preview>
-  <Story name="Live, throbbing">
-    <LastUpdated live throbbing date={new Date('1987-01-05T00:00:00.00')} />
+  <Story name="Live, dot">
+    <LastUpdated live dot date={new Date('1987-01-05T00:00:00.00')} />
   </Story>
 </Preview>
 
-Live, only throbber:
+Live, only dot:
 
 <Preview>
-  <Story name="Live, throbbing without date">
-    <LastUpdated live throbbing />
+  <Story name="Live, dot without date">
+    <LastUpdated live dot />
   </Story>
 </Preview>
 

--- a/src/last-updated/index.stories.mdx
+++ b/src/last-updated/index.stories.mdx
@@ -3,26 +3,67 @@ import LastUpdated from './';
 
 <Meta title="Core|Last Updated" component={LastUpdated} />
 
-# Last Updated timer component component
-
-This disappears if not provided a date object.
+# Last Updated component
 
 <Preview>
-  <Story name="Default (live) variant">
-    <LastUpdated lastUpdated={new Date('1987-01-05T00:00:00.00')} />
-  </Story>
-  <Story name="Light variant">
-    <LastUpdated live={false} lastUpdated={new Date('1987-01-05T00:00:00.00')} />
+  <Story name="Standard">
+    <LastUpdated date={new Date('1987-01-05T00:00:00.00')} />
   </Story>
 </Preview>
 
-If you don't provide a date to the `lastUpdated` prop, you won't see anything.
+With throbber:
 
 <Preview>
-  <Story name="No date provided (live)">
+  <Story name="Standard, throbbing">
+    <LastUpdated throbbing date={new Date('1987-01-05T00:00:00.00')} />
+  </Story>
+</Preview>
+
+Only throbber:
+
+<Preview>
+  <Story name="Standard, throbbing without date">
+    <LastUpdated throbbing />
+  </Story>
+</Preview>
+
+If you don't provide a date, you won't see anything:
+
+<Preview>
+  <Story name="Standard, without date">
     <LastUpdated />
   </Story>
-  <Story name="No date provided (not live; invisible)">
-    <LastUpdated live={false} />
+</Preview>
+
+
+The live version has a red background:
+
+<Preview>
+  <Story name="Live">
+    <LastUpdated live date={new Date('1987-01-05T00:00:00.00')} />
+  </Story>
+</Preview>
+
+Live, with throbber:
+
+<Preview>
+  <Story name="Live, throbbing">
+    <LastUpdated live throbbing date={new Date('1987-01-05T00:00:00.00')} />
+  </Story>
+</Preview>
+
+Live, only throbber:
+
+<Preview>
+  <Story name="Live, throbbing without date">
+    <LastUpdated live throbbing />
+  </Story>
+</Preview>
+
+Live, without a date provided:
+
+<Preview>
+  <Story name="Live, without date">
+    <LastUpdated live />
   </Story>
 </Preview>


### PR DESCRIPTION
So we can have a non-live 'last updated' with a red dot. Should be clear from the Storybook.
