### PR TITLE
Update share component

### DIFF
--- a/src/big-topper/index.js
+++ b/src/big-topper/index.js
@@ -13,12 +13,17 @@ import { mainImagePropType, topicPropType, bylinesPropType, flagsPropType } from
 import './styles.scss';
 
 const BigTopper = ({
+  url,
   topic,
   headline,
   summary,
   relatedArticle,
   mainImage,
   bylines,
+  socialHeadline,
+  twitterHeadline,
+  facebookHeadline,
+  tweetText,
   flags,
   ...props
 }) => {
@@ -53,7 +58,15 @@ const BigTopper = ({
 
       {bylines && (<Bylines prefix="By" names={bylines} date={publishedDate} />)}
 
-      <Share headline={headline} {...{ ...props, flags }} />
+      {flags.shareButtons && (
+        <Share
+          url={url}
+          text={socialHeadline || headline}
+          textTwitter={tweetText || twitterHeadline}
+          textFacebook={facebookHeadline}
+          dark={flags.dark}
+        />
+      )}
 
       {summary && (
         <p className="o-editorial-typography-standfirst">
@@ -72,6 +85,7 @@ const BigTopper = ({
 };
 
 BigTopper.propTypes = {
+  url: PropTypes.string.isRequired,
   topic: topicPropType,
   headline: PropTypes.string.isRequired,
   summary: PropTypes.string,
@@ -81,6 +95,10 @@ BigTopper.propTypes = {
   }),
   mainImage: mainImagePropType,
   bylines: bylinesPropType,
+  socialHeadline: PropTypes.string,
+  twitterHeadline: PropTypes.string,
+  facebookHeadline: PropTypes.string,
+  tweetText: PropTypes.string,
   flags: flagsPropType.isRequired,
   publishedDate: PropTypes.string.isRequired,
   buildTime: PropTypes.string.isRequired,

--- a/src/big-topper/styles.scss
+++ b/src/big-topper/styles.scss
@@ -37,8 +37,8 @@ $o-typography-is-silent: false;
   margin-bottom: 38px;
 }
 
-.big-topper .article__share {
-  margin-top: 13px;
+.big-topper .g-share {
+  margin-bottom: 15px;
 }
 
 .big-topper .o-editorial-typography-standfirst {

--- a/src/share/index.js
+++ b/src/share/index.js
@@ -6,21 +6,19 @@
 import React, { useEffect, useRef } from 'react';
 import OShare from '@financial-times/o-share';
 import PropTypes from 'prop-types';
-import { flagsPropType } from '../shared/proptypes';
 import './styles.scss';
 
 const Share = ({
-  headline,
-  twitterHeadline,
-  socialHeadline,
-  twitterRelatedAccounts,
   url,
-  tweetText,
-  flags,
+  text,
+  textTwitter,
+  textFacebook,
+  textLinkedIn,
+  textWhatsApp,
+  separated,
+  dark,
 }) => {
   const ref = useRef();
-
-  const { shareButtons, dark } = flags;
 
   useEffect(() => {
     (async () => {
@@ -28,76 +26,69 @@ const Share = ({
     })();
   }, []);
 
-  if (!shareButtons) return null;
+  const services = [
+    {
+      name: 'Twitter',
+      link: 'https://twitter.com/intent/tweet'
+        + `?url=${url}`
+        + `&text=${textTwitter || text}`
+        + '&via=FinancialTimes',
+    },
+    {
+      name: 'Facebook',
+      link: 'https://www.facebook.com/sharer.php'
+        + `?u=${url}`
+        + `&t=${textFacebook || text}`,
+    },
+    {
+      name: 'LinkedIn',
+      link: 'https://www.linkedin.com/shareArticle'
+        + '?mini=true'
+        + `&url=${url}`
+        + `&title=${textLinkedIn || text}`
+        + `&source=Financial+Times`,
+    },
+    {
+      name: 'WhatsApp',
+      link: `whatsapp://send?text=${textWhatsApp || text} - ${url}`,
+    },
+  ];
 
-  const containerClasses = ['container', dark && 'container--inverse'].filter(i => i).join(' ');
-  const sharingClasses = ['o-share', dark && 'o-share--inverse'].filter(i => i).join(' ');
-  const services = new Map([
-    [
-      'Twitter',
-      `https://twitter.com/intent/tweet?url=${url}&amp;text=${tweetText ||
-        twitterHeadline ||
-        socialHeadline ||
-        headline}${twitterRelatedAccounts &&
-        `&amp;related=${twitterRelatedAccounts.join(',')}`}&amp;via=FinancialTimes`,
-    ],
-    ['Facebook', `http://www.facebook.com/sharer.php?u=${url}`],
-    [
-      'LinkedIn',
-      `https://www.linkedin.com/shareArticle?mini=true&amp;url=${url}&amp;source=Financial%20Times`,
-    ],
-    ['WhatsApp', `whatsapp://send?text=${socialHeadline || headline}%20-%20${url}`],
-  ]);
   return (
-    <div
-      className="article__share article__share--top n-util-clearfix"
-      data-trackable="share | top"
-    >
-      <div className={containerClasses}>
-        <div ref={ref} data-o-component="o-share" className={sharingClasses}>
-          <ul>
-            {[...services.entries()].map(([serviceName, link]) => (
-              <li className={`o-share__action o-share__action--${serviceName.toLowerCase()}`}>
-                <a
-                  className={`o-share__icon o-share__icon--${serviceName.toLowerCase()}`}
-                  href={link}
-                  rel="noopener"
-                  data-trackable={serviceName.toLowerCase()}
-                >
-                  <span className="o-share__text">
-                    Share on {serviceName}. Opens in a new window.
-                  </span>
-                </a>
-              </li>
-            ))}
-          </ul>
-        </div>
+    <div className={['g-share', separated && 'g-share--separated'].join(' ')}>
+      <div
+        className={['o-share', dark && 'o-share--inverse'].join(' ')}
+        data-o-component="o-share"
+      >
+        <ul>
+          {services.map(({ name, link }) => (
+            <li className="o-share__action">
+              <a
+                className={`o-share__icon o-share__icon--${name.toLowerCase()}`}
+                href={link}
+                rel="noopener"
+              >
+                <span className="o-share__text">
+                  Share on {name}. Opens in a new window.
+                </span>
+              </a>
+            </li>
+          ))}
+        </ul>
       </div>
     </div>
   );
 };
 
-Share.displayName = 'GShare';
-
 Share.propTypes = {
   url: PropTypes.string.isRequired,
-  socialHeadline: PropTypes.string,
-  twitterHeadline: PropTypes.string,
-  headline: PropTypes.string,
-  twitterRelatedAccounts: PropTypes.arrayOf(PropTypes.string),
-  tweetText: PropTypes.string,
-  flags: flagsPropType,
-};
-
-Share.defaultProps = {
-  tweetText: 'FT article: ',
-  socialHeadline: '',
-  twitterHeadline: '',
-  headline: '',
-  twitterRelatedAccounts: [],
-  flags: {
-    dark: false,
-  },
+  text: PropTypes.string.isRequired,
+  textTwitter: PropTypes.string,
+  textFacebook: PropTypes.string,
+  textLinkedIn: PropTypes.string,
+  textWhatsApp: PropTypes.string,
+  separated: PropTypes.bool,
+  dark: PropTypes.bool,
 };
 
 Share.displayName = 'GShare';

--- a/src/share/index.js
+++ b/src/share/index.js
@@ -62,7 +62,7 @@ const Share = ({
       >
         <ul>
           {services.map(({ name, link }) => (
-            <li className="o-share__action">
+            <li key={name} className="o-share__action">
               <a
                 className={`o-share__icon o-share__icon--${name.toLowerCase()}`}
                 href={link}

--- a/src/share/index.stories.mdx
+++ b/src/share/index.stories.mdx
@@ -5,10 +5,39 @@ import Share from './';
 
 # Share component
 
-tktk
-
 <Preview>
   <Story name="Basic">
-    <Share url="https://www.aendrew.com" />
+    <Share
+      text="My favourite website"
+      url="https://www.ft.com/visual-and-data-journalism"
+    />
+  </Story>
+</Preview>
+
+
+## Separated
+
+<Preview>
+  <Story name="Separated">
+    <Share
+      text="My favourite website"
+      url="https://www.ft.com/visual-and-data-journalism"
+      separated
+    />
+  </Story>
+</Preview>
+
+
+## Dark mode
+
+(the icons are white)
+
+<Preview>
+  <Story name="Dark mode">
+    <Share
+      text="My favourite website"
+      url="https://www.ft.com/visual-and-data-journalism"
+      dark
+    />
   </Story>
 </Preview>

--- a/src/share/styles.scss
+++ b/src/share/styles.scss
@@ -1,3 +1,20 @@
 $o-share-is-silent: false;
 @import '../shared/_globals.scss';
 @import 'o-share/main.scss';
+@import 'o-grid/main';
+
+.g-share.g-share--separated li {
+  margin-left: 16px;
+}
+
+.g-share.g-share--separated li:first-of-type {
+  margin-left: 0;
+}
+
+@include oGridRespondTo(S) {
+
+  .g-share .o-share__icon--whatsapp {
+    display: none;
+  }
+
+}

--- a/src/shared/critical-path.scss
+++ b/src/shared/critical-path.scss
@@ -75,11 +75,6 @@ body {
   &-head {
     margin-top: 18px;
     margin-bottom: 0;
-
-    .article__share {
-      margin-top: 15px;
-      margin-bottom: 15px;
-    }
   }
 
   // This was in the original Starter Kit styles.scss but prevents
@@ -91,15 +86,6 @@ body {
   //     }
   //   }
   // }
-}
-
-/* Hide whatsapp share button on desktop */
-.article__share {
-  @include oGridRespondTo(S) {
-    .o-share__icon--whatsapp {
-      display: none;
-    }
-  }
 }
 
 .graphic {

--- a/src/story-topper/index.js
+++ b/src/story-topper/index.js
@@ -13,12 +13,17 @@ import { mainImagePropType, bylinesPropType, topicPropType, flagsPropType } from
 import './styles.scss';
 
 const StoryTopper = ({
+  url,
   topic,
   headline,
   summary,
   relatedArticle,
   mainImage,
   bylines,
+  socialHeadline,
+  twitterHeadline,
+  facebookHeadline,
+  tweetText,
   flags,
   ...props
 }) => {
@@ -64,7 +69,15 @@ const StoryTopper = ({
         </figure>
       )}
 
-      <Share headline={headline} {...{ ...props, flags }} />
+      {flags.shareButtons && (
+        <Share
+          url={url}
+          text={socialHeadline || headline}
+          textTwitter={tweetText || twitterHeadline}
+          textFacebook={facebookHeadline}
+          dark={flags.dark}
+        />
+      )}
 
       <Bylines names={bylines} date={publishedDate} />
     </div>
@@ -72,6 +85,7 @@ const StoryTopper = ({
 };
 
 StoryTopper.propTypes = {
+  url: PropTypes.string.isRequired,
   topic: topicPropType,
   headline: PropTypes.string.isRequired,
   summary: PropTypes.string,
@@ -81,6 +95,10 @@ StoryTopper.propTypes = {
   }),
   mainImage: mainImagePropType,
   bylines: bylinesPropType,
+  socialHeadline: PropTypes.string,
+  twitterHeadline: PropTypes.string,
+  facebookHeadline: PropTypes.string,
+  tweetText: PropTypes.string,
   flags: flagsPropType.isRequired,
   publishedDate: PropTypes.string.isRequired,
   buildTime: PropTypes.string.isRequired,

--- a/src/story-topper/styles.scss
+++ b/src/story-topper/styles.scss
@@ -15,8 +15,9 @@ $o-typography-is-silent: false;
   margin-top: 4px;
 }
 
-.story-topper .article__share {
+.story-topper .g-share {
   margin-top: 13px;
+  margin-bottom: 15px;
 }
 
 .story-topper .bylines {


### PR DESCRIPTION
The US polltracker has share buttons at the bottom of the page instead of in the topper. These changes try to make the Share component something that can be used whereever in a page rather than something expected to be used in the topper only.

* It used to not render if `props.shareButtons` was set to `false`, but if you want to use the component elsewhere on the page that doesn't make sense (this was my fault actually, whoops)
* The LinkedIn URL was wrong, so fixes that
* Updates the HTML to be per latest Origami
* Adds `separated` attribute which adds some margin between buttons, a style we seem to use often
* Added support for using text specific to WhatsApp or LinkedIn, in line with existing support for doing that on Twitter and Facebook