### PR TITLE
Uncomment button styles import

### DIFF
--- a/src/button/index.js
+++ b/src/button/index.js
@@ -7,7 +7,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import validIcons from './icons';
-// import './styles.scss'; // @TODO FIX
+import './styles.scss';
 
 /* eslint-disable react/button-has-type */
 export const Button = ({


### PR DESCRIPTION
This fixes the issues where origami button styles were not appearing in projects that used the latest version of g-components