### PR TITLE
Fix autosuggest style issues introduced by origami

### DIFF
--- a/src/autosuggest-search/styles.scss
+++ b/src/autosuggest-search/styles.scss
@@ -73,6 +73,8 @@
   }
 
   &__selected-value {
+    font-family: MetricWeb, sans-serif;
+    font-size: 16px;
     display: flex;
     align-items: center;
     height: 32px;
@@ -123,6 +125,11 @@
 
     &::placeholder {
       text-transform: none;
+    }
+
+    &--focused {
+      outline: none !important;
+      box-shadow: none !important;
     }
 
     &--open {


### PR DESCRIPTION
Font was wrong on selected value tokens and a grey border appeared around the input on focus - these are now removed