### PR TITLE
Add prop to allow skipping image service

### DIFF
--- a/src/image-set/index.js
+++ b/src/image-set/index.js
@@ -14,22 +14,31 @@ function imageURL(url, width) {
   return `https://www.ft.com/__origami/service/image/v2/images/raw/${url}?source=ig&amp;fit=scale-down&amp;quality=highest&amp;width=${width}`;
 }
 
-function getImageURL(imgString, width) {
+function getImageURL(imgString, width, skipImageService) {
+  if (skipImageService) return imgString;
   if (imgString.startsWith('http')) return imageURL(imgString, width);
   return imageUUID(imgString, width);
 }
 
-const ImageSet = ({ alt, sources }) => (
+const ImageSet = ({ alt, sources, skipImageService }) => (
   <div className="g-imageset">
     <figure>
       <picture>
         {sources && sources.small && (
-          <source media="screen and (max-width: 490px)" srcSet={getImageURL(sources.small, 490)} />
+          <source
+            media="screen and (max-width: 490px)"
+            srcSet={getImageURL(sources.small, 490, skipImageService)}
+          />
         )}
         {sources && sources.large && (
-          <source media="screen and (min-width: 980px)" srcSet={getImageURL(sources.large, 1260)} />
+          <source
+            media="screen and (min-width: 980px)"
+            srcSet={getImageURL(sources.large, 1260, skipImageService)}
+          />
         )}
-        {sources && sources.medium && <img srcSet={getImageURL(sources.medium, 700)} alt={alt} />}
+        {sources && sources.medium && (
+          <img srcSet={getImageURL(sources.medium, 700, skipImageService)} alt={alt} />
+        )}
       </picture>
     </figure>
   </div>
@@ -42,6 +51,11 @@ ImageSet.propTypes = {
     medium: PropTypes.string,
     large: PropTypes.string,
   }).isRequired,
+  skipImageService: PropTypes.bool,
+};
+
+ImageSet.defaultProps = {
+  skipImageService: false,
 };
 
 export default ImageSet;

--- a/src/image-set/index.stories.mdx
+++ b/src/image-set/index.stories.mdx
@@ -10,14 +10,31 @@ Component for displaying small, medium and large images in a set.
 Breakpoints are at 490px and 980px.
 
 <Preview>
-  <Story name="Example">
-    <ImageSet
-      alt="Demo image set"
-      sources={{
-        small: '61b2c912-0d49-11ea-bb52-34c8d9dc6d84',
-        medium: '5f35b8b6-0d49-11ea-bb52-34c8d9dc6d84',
-        large: '5c9b8478-0d49-11ea-bb52-34c8d9dc6d84',
-      }}
-    />
+  <Story name="Exampl2e">
+    <>
+      <div>
+        Basic image set
+      </div>
+      <ImageSet
+        alt="Demo image set"
+        sources={{
+          small: '61b2c912-0d49-11ea-bb52-34c8d9dc6d84',
+          medium: '5f35b8b6-0d49-11ea-bb52-34c8d9dc6d84',
+          large: '5c9b8478-0d49-11ea-bb52-34c8d9dc6d84',
+        }}
+      />
+      <div>
+        Image set using SVGs, skipping the image service
+      </div>
+      <ImageSet
+        alt="Demo image set"
+        sources={{
+          small: 'https://ig.ft.com/autograph/graphics/us-2020-polltracker.svg?frame=webS',
+          medium: 'https://ig.ft.com/autograph/graphics/us-2020-polltracker.svg?frame=webM',
+          large: 'https://ig.ft.com/autograph/graphics/us-2020-polltracker.svg?frame=webM',
+        }}
+        skipImageService
+      />
+    </>
   </Story>
 </Preview>

--- a/src/image-set/index.stories.mdx
+++ b/src/image-set/index.stories.mdx
@@ -10,7 +10,7 @@ Component for displaying small, medium and large images in a set.
 Breakpoints are at 490px and 980px.
 
 <Preview>
-  <Story name="Exampl2e">
+  <Story name="Example">
     <>
       <div>
         Basic image set


### PR DESCRIPTION
Presently, the ImageSet runs all URLs through the image service, which doesn't work with SVGs.

This PR adds a prop to allow skipping the image service (though it still uses it by default).