### PR TITLE
Change onward journey link style and get rid of border-bottom under imgs

### DIFF
--- a/src/onwardjourney/styles.scss
+++ b/src/onwardjourney/styles.scss
@@ -3,7 +3,25 @@ $o-teaser-is-silent: false;
 @import '../shared/_globals.scss';
 @import 'o-teaser/main';
 
+.onward-journey .o-teaser a {
+  border-bottom: none;
+}
+
 .onward-journey__link {
-  color: #333;
+  color: #33302e;
   text-decoration: none;
+
+  h3 {
+    font-weight: 600;
+
+    &:after {
+      content: "";
+      display: block;
+      width: 60px;
+      margin-top: 5px;
+      border-bottom: 4px solid #000;
+      position: absolute;
+      z-index: 1;
+    }
+  }
 }


### PR DESCRIPTION
![Screen Shot 2020-07-29 at 14 59 51](https://user-images.githubusercontent.com/1794257/88810005-af121780-d1ac-11ea-8cb0-9d2171970a6b.png)

Related to https://github.com/Financial-Times/ig-us-election-2020/issues/147 and https://github.com/Financial-Times/ig-us-election-2020/issues/148