### PR TITLE
Add font family to autosuggest-search error message

### DIFF
--- a/src/autosuggest-search/styles.scss
+++ b/src/autosuggest-search/styles.scss
@@ -41,6 +41,7 @@
   }
 
   &__error-message {
+    font-family: MetricWeb, sans-serif;
     font-size: 14px;
     line-height: 1.43;
     color: #cc0000;


### PR DESCRIPTION
With the o-typography update we lost the MetricWeb font being applied to the error message (see below). This fixes that 

<img width="604" alt="Screenshot 2020-07-29 at 16 35 41" src="https://user-images.githubusercontent.com/6597881/88820702-90fee400-d1b9-11ea-8202-e78ca5915246.png">
