### PR TITLE
Adds es2019 to default polyfill bundle

### DIFF
--- a/src/html-head/index.js
+++ b/src/html-head/index.js
@@ -42,9 +42,8 @@ const HtmlHead = ({
   twitterHeadline,
   twitterImage,
   url,
-  polyfills,
+  polyfillFeatures,
 }) => {
-  const polyfillFeatures = polyfills.join(',');
   const mainImageUrl = getMainImage(mainImage);
   const Tag = wrapWithHeadTags ? 'head' : Fragment;
 
@@ -138,7 +137,7 @@ const HtmlHead = ({
       )}
 
       {/* Add polyfill service */}
-      <script src={`https://cdn.polyfill.io/v3/polyfill.min.js?features=${polyfillFeatures}`} />
+      <script src={`https://cdn.polyfill.io/v3/polyfill.min.js?features=${polyfillFeatures.join(',')}`} />
 
       {/* Add CTM checks */}
       <script
@@ -234,7 +233,7 @@ HtmlHead.propTypes = {
   twitterHeadline: PropTypes.string,
   twitterImage: PropTypes.string,
   url: PropTypes.string.isRequired,
-  polyfills: PropTypes.arrayOf(PropTypes.string),
+  polyfillFeatures: PropTypes.arrayOf(PropTypes.string),
 };
 
 const DEFAULTS = {
@@ -268,7 +267,7 @@ HtmlHead.defaultProps = {
   tracking: {
     product: 'IG',
   },
-  polyfills: ['default', 'fetch', 'es2019'],
+  polyfillFeatures: ['default', 'fetch', 'es2019'],
 };
 
 HtmlHead.displayName = 'GHtmlHead';

--- a/src/html-head/index.js
+++ b/src/html-head/index.js
@@ -138,7 +138,7 @@ const HtmlHead = ({
       )}
 
       {/* Add polyfill service */}
-      <script src={`https://cdn.polyfill.io/v2/polyfill.min.js?features=${polyfillFeatures}`} />
+      <script src={`https://cdn.polyfill.io/v3/polyfill.min.js?features=${polyfillFeatures}`} />
 
       {/* Add CTM checks */}
       <script

--- a/src/html-head/index.js
+++ b/src/html-head/index.js
@@ -268,7 +268,7 @@ HtmlHead.defaultProps = {
   tracking: {
     product: 'IG',
   },
-  polyfills: ['default', 'fetch'],
+  polyfills: ['default', 'fetch', 'es2019'],
 };
 
 HtmlHead.displayName = 'GHtmlHead';


### PR DESCRIPTION
Includes:

* Array.prototype.flat
* Array.prototype.flatMap
* Object.fromEntries
* String.prototype.trimEnd
* String.prototype.trimStart

See: https://github.com/Financial-Times/ig-us-election-2020/issues/116