### PR TITLE
Use ftDateFormat for ftTime function rather than oDate in order to re…

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react-dom": "^16.13.1"
   },
   "dependencies": {
+    "@financial-times/ft-date-format": "^1.0.4",
     "@financial-times/o-ads": "^18.0.0",
     "@financial-times/o-buttons": "^6.0.13",
     "@financial-times/o-comments": "^7.5.2",

--- a/src/datetime/index.js
+++ b/src/datetime/index.js
@@ -5,6 +5,7 @@
 import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import ODate from '@financial-times/o-date';
+import ftDateFormat from '@financial-times/ft-date-format';
 
 const DateTime = ({ datestamp }) => {
   const elRef = useRef(null);
@@ -21,7 +22,7 @@ const DateTime = ({ datestamp }) => {
       className="o-date"
       dateTime={datestamp.toISOString()}
     >
-      {ODate.ftTime(datestamp)}
+      {ftDateFormat.ftTime(datestamp)}
     </time>
   );
 };


### PR DESCRIPTION
…move oDate deprecated function warning.

![Screenshot 2020-10-05 at 14 44 59](https://user-images.githubusercontent.com/1282239/95087288-68471d80-0719-11eb-860a-438593030782.png)
