### PR TITLE
Add default sort icon attribute to data-table headers and init table on each render

### DIFF
--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -3410,6 +3410,125 @@ Array [
       </div>
     </div>
   </div>,
+  "With default sort icon:",
+  <div
+    className="g-data-table o-table-scroll-wrapper"
+  >
+    <table
+      className="o-table"
+      data-o-component="o-table"
+    >
+      <thead>
+        <tr>
+          <th
+            aria-sort="descending"
+            className="o-table__cell--numeric"
+            data-o-table-data-type="numeric"
+            role="columnheader"
+            scope="col"
+          >
+            Year
+          </th>
+          <th
+            role="columnheader"
+            scope="col"
+          >
+            Editor
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td
+            className="o-table__cell--numeric"
+            data-o-table-data-type="numeric"
+          >
+            2020
+          </td>
+          <td>
+            Roula Khalaf
+          </td>
+        </tr>
+        <tr>
+          <td
+            className="o-table__cell--numeric"
+            data-o-table-data-type="numeric"
+          >
+            2006
+          </td>
+          <td>
+            Lionel Barber
+          </td>
+        </tr>
+        <tr>
+          <td
+            className="o-table__cell--numeric"
+            data-o-table-data-type="numeric"
+          >
+            2001
+          </td>
+          <td>
+            Andrew Gowers
+          </td>
+        </tr>
+        <tr>
+          <td
+            className="o-table__cell--numeric"
+            data-o-table-data-type="numeric"
+          >
+            1991
+          </td>
+          <td>
+            Richard Lambert
+          </td>
+        </tr>
+        <tr>
+          <td
+            className="o-table__cell--numeric"
+            data-o-table-data-type="numeric"
+          >
+            1981
+          </td>
+          <td>
+            Sir Geoffrey Owen
+          </td>
+        </tr>
+        <tr>
+          <td
+            className="o-table__cell--numeric"
+            data-o-table-data-type="numeric"
+          >
+            1973
+          </td>
+          <td>
+            Fredy Fisher
+          </td>
+        </tr>
+        <tr>
+          <td
+            className="o-table__cell--numeric"
+            data-o-table-data-type="numeric"
+          >
+            1949
+          </td>
+          <td>
+            Sir Gordon Newton
+          </td>
+        </tr>
+        <tr>
+          <td
+            className="o-table__cell--numeric"
+            data-o-table-data-type="numeric"
+          >
+            1945
+          </td>
+          <td>
+            Hargreaves Parkinson
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>,
 ]
 `;
 

--- a/src/data-table/index.js
+++ b/src/data-table/index.js
@@ -18,6 +18,7 @@ const headerAttributes = (header, isSortable) => {
       ? { 'data-o-table-heading-disable-sort': '' }
       : {},
     { scope: 'col', role: 'columnheader' },
+    header.defaultSortIcon && isSortable ? { 'aria-sort': header.defaultSortIcon } : {},
   ];
   return Object.assign(...attributes);
 };
@@ -180,7 +181,7 @@ const DataTable = ({
 
   useEffect(() => {
     tableOrigami.current = OTable.init(tableRef.current);
-  }, []);
+  });
 
   // @TODO fix this; private method OTable.prototype._duplicateHeaders
   // useEffect(() => {
@@ -239,6 +240,7 @@ DataTable.propTypes = {
       columnIsHeader: PropTypes.bool,
       columnIsSortable: PropTypes.bool,
       columnIsVerticallyCentred: PropTypes.bool,
+      defaultSortIcon: PropTypes.oneOf(['ascending', 'descending'])
     }),
   ).isRequired,
   rows: PropTypes.arrayOf(PropTypes.object),

--- a/src/data-table/index.stories.mdx
+++ b/src/data-table/index.stories.mdx
@@ -13,6 +13,19 @@ export const basicHeaders = [
   },
 ];
 
+export const headersWithDefaultSortIcon = [
+    {
+    contents: 'Year',
+    columnType: 'number',
+    columnName: 'appointed',
+    defaultSortIcon: 'descending',
+  },
+  {
+    contents: 'Editor',
+    columnName: 'name',
+  },
+]
+
 export const basicRows = [
   { appointed: '2020', name: 'Roula Khalaf' },
   { appointed: '2006', name: 'Lionel Barber' },
@@ -54,6 +67,8 @@ export const basicRows = [
       <DataTable headers={basicHeaders} rows={basicRows} responsive="flat" />
       Sorting disabled:
       <DataTable headers={basicHeaders} rows={basicRows} responsive="flat" isSortable={false} />
+      With default sort icon:
+      <DataTable headers={headersWithDefaultSortIcon} rows={basicRows} />
     </>
   </Story>
 </Canvas>


### PR DESCRIPTION
Fixes issue where table is not properly initialised and sorting does not work unless the page is refreshed but this comes at the cost of running OTable.init() each time the table is re-rendered. In most scenarios, this won't be often

Adds attribute to headers which allows a default sort icon to be set (you still have to sort on the column yourself)