### PR TITLE
Add wrapper for comments and move o-grid colspan attribute to wrapper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1537,9 +1537,9 @@
       }
     },
     "@financial-times/o-comments": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-comments/-/o-comments-7.6.0.tgz",
-      "integrity": "sha512-2ISkX8pYjNtdG8AjXKKnbprIXKaXcjUrDGO6HO2x9d+r1b60RaUWPoPHfQBTZJGjLbyLT6PNscel6F3icCD3xQ==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-comments/-/o-comments-7.7.4.tgz",
+      "integrity": "sha512-GJs6LiIEl2REHQRxTBWdkHcPyYbBf06rhd6jQXh0tV4tiIwHDmj9228EK3ZtsPzJm61CMxtN4tObDyWYZjAmmg==",
       "requires": {
         "@financial-times/o-buttons": "^6.0.2",
         "@financial-times/o-colors": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@financial-times/ft-date-format": "^1.0.4",
     "@financial-times/o-ads": "^18.0.0",
     "@financial-times/o-buttons": "^6.0.13",
-    "@financial-times/o-comments": "^7.5.2",
+    "@financial-times/o-comments": "^7.7.4",
     "@financial-times/o-date": "^4.0.5",
     "@financial-times/o-editorial-layout": "^1.1.3",
     "@financial-times/o-editorial-typography": "^1.0.10",

--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -2484,20 +2484,23 @@ exports[`Storyshots Core/Comments Basic 1`] = `
     className="o-grid-row"
   >
     <div
-      data-o-component="o-comments"
       data-o-grid-colspan="12 S11 Scenter M9 L8 XL7"
-      id="comments"
     >
       <div
-        className="o--if-no-js"
+        data-o-component="o-comments"
+        id="comments"
       >
-        To participate in this chat, you need to upgrade to a newer web browser.
-         
-        <a
-          href="https://help.ft.com/tools-services/browser-compatibility/"
+        <div
+          className="o--if-no-js"
         >
-          Learn more.
-        </a>
+          To participate in this chat, you need to upgrade to a newer web browser.
+           
+          <a
+            href="https://help.ft.com/tools-services/browser-compatibility/"
+          >
+            Learn more.
+          </a>
+        </div>
       </div>
     </div>
   </div>
@@ -13014,20 +13017,23 @@ Array [
       className="o-grid-row"
     >
       <div
-        data-o-component="o-comments"
         data-o-grid-colspan="12 S11 Scenter M9 L8 XL7"
-        id="comments"
       >
         <div
-          className="o--if-no-js"
+          data-o-component="o-comments"
+          id="comments"
         >
-          To participate in this chat, you need to upgrade to a newer web browser.
-           
-          <a
-            href="https://help.ft.com/tools-services/browser-compatibility/"
+          <div
+            className="o--if-no-js"
           >
-            Learn more.
-          </a>
+            To participate in this chat, you need to upgrade to a newer web browser.
+             
+            <a
+              href="https://help.ft.com/tools-services/browser-compatibility/"
+            >
+              Learn more.
+            </a>
+          </div>
         </div>
       </div>
     </div>

--- a/src/comments/index.js
+++ b/src/comments/index.js
@@ -27,15 +27,12 @@ const Comments = ({ id, url, linkPageUrl, flags }) => {
   const comments = (
     <div className="o-grid-container">
       <div className="o-grid-row">
-        <div
-          ref={ref}
-          data-o-component="o-comments"
-          id="comments"
-          data-o-grid-colspan="12 S11 Scenter M9 L8 XL7"
-        >
-          <div className="o--if-no-js">
-            To participate in this chat, you need to upgrade to a newer web browser.{' '}
-            <a href="https://help.ft.com/tools-services/browser-compatibility/">Learn more.</a>
+        <div data-o-grid-colspan="12 S11 Scenter M9 L8 XL7">
+          <div ref={ref} data-o-component="o-comments" id="comments">
+            <div className="o--if-no-js">
+              To participate in this chat, you need to upgrade to a newer web browser.{' '}
+              <a href="https://help.ft.com/tools-services/browser-compatibility/">Learn more.</a>
+            </div>
           </div>
         </div>
       </div>

--- a/src/comments/styles.scss
+++ b/src/comments/styles.scss
@@ -1,8 +1,3 @@
 $o-comments-is-silent: false;
 @import '../shared/_globals.scss';
 @import 'o-comments/main.scss';
-
-.o-comments__signed-in-container {
-  width: 100%;
-  text-align: center;
-}

--- a/src/comments/styles.scss
+++ b/src/comments/styles.scss
@@ -1,3 +1,8 @@
 $o-comments-is-silent: false;
 @import '../shared/_globals.scss';
 @import 'o-comments/main.scss';
+
+.o-comments__signed-in-container {
+  width: 100%;
+  text-align: center;
+}


### PR DESCRIPTION
The signed in container is added before the comments container https://github.com/Financial-Times/o-comments/blob/master/src/js/stream.js#L210 so I think a better solution is to wrap this element in a div and move the o-grid colspan to it