### PR TITLE
Adds sticky header component

### DIFF
--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -7481,6 +7481,323 @@ exports[`Storyshots Core/Sticky Complex example 1`] = `
 </div>
 `;
 
+exports[`Storyshots Core/Sticky Header With changing height of children 1`] = `
+Array [
+  <div
+    style={
+      Object {
+        "border": "1px solid red",
+        "height": 2000,
+        "position": "relative",
+      }
+    }
+  >
+    <div>
+      <h1>
+        Title
+      </h1>
+      <div
+        className="sticky-header"
+        style={
+          Object {
+            "minHeight": "auto",
+          }
+        }
+      >
+        <div
+          className="sticky-header__children-wrapper"
+          style={
+            Object {
+              "top": 0,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "backgroundColor": "white",
+                "borderBottom": "1px solid black",
+                "height": 30,
+              }
+            }
+          >
+            Sticky header child
+          </div>
+          <div
+            style={
+              Object {
+                "backgroundColor": "yellow",
+                "borderBottom": "1px solid black",
+                "display": "block",
+                "height": 30,
+              }
+            }
+          >
+            Sticky header child 2
+          </div>
+        </div>
+      </div>
+      <h2>
+        Section title
+      </h2>
+      <p>
+        Ik kie neġi æpude pōsÞpriskribo, anċ ēg tiel subtegmenÞo. Giga gārði esperǣntigo vi jes. Ċit plēj esceptīnte hu, ōl vola eksploðæ poǽ. Ōīð gh pǽƿjo s'joro pronomeċa, mi paki vice fiksa vir. Trǣ kibi multa ok, sur ðū īnfāno kæŭze. Om ene modō sekvanta proksimumecō, ānÞ sh tiele hiper defīnītive.
+      </p>
+      <h2>
+        Section title
+      </h2>
+      <p>
+        Ik kie neġi æpude pōsÞpriskribo, anċ ēg tiel subtegmenÞo. Giga gārði esperǣntigo vi jes. Ċit plēj esceptīnte hu, ōl vola eksploðæ poǽ. Ōīð gh pǽƿjo s'joro pronomeċa, mi paki vice fiksa vir. Trǣ kibi multa ok, sur ðū īnfāno kæŭze. Om ene modō sekvanta proksimumecō, ānÞ sh tiele hiper defīnītive.
+      </p>
+      <h2>
+        Section title
+      </h2>
+      <p>
+        Ik kie neġi æpude pōsÞpriskribo, anċ ēg tiel subtegmenÞo. Giga gārði esperǣntigo vi jes. Ċit plēj esceptīnte hu, ōl vola eksploðæ poǽ. Ōīð gh pǽƿjo s'joro pronomeċa, mi paki vice fiksa vir. Trǣ kibi multa ok, sur ðū īnfāno kæŭze. Om ene modō sekvanta proksimumecō, ānÞ sh tiele hiper defīnītive.
+      </p>
+    </div>
+  </div>,
+  <footer
+    style={
+      Object {
+        "height": 2000,
+      }
+    }
+  />,
+]
+`;
+
+exports[`Storyshots Core/Sticky Header With missing containerRef 1`] = `
+Array [
+  <div>
+    <h1>
+      Title
+    </h1>
+    <div
+      className="sticky-header"
+      style={
+        Object {
+          "minHeight": "auto",
+        }
+      }
+    >
+      <div
+        className="sticky-header__children-wrapper"
+        style={
+          Object {
+            "top": 0,
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "backgroundColor": "white",
+              "borderBottom": "1px solid black",
+              "height": 30,
+            }
+          }
+        >
+          Sticky header child
+        </div>
+      </div>
+    </div>
+    <h2>
+      Section title
+    </h2>
+    <p>
+      Ik kie neġi æpude pōsÞpriskribo, anċ ēg tiel subtegmenÞo. Giga gārði esperǣntigo vi jes. Ċit plēj esceptīnte hu, ōl vola eksploðæ poǽ. Ōīð gh pǽƿjo s'joro pronomeċa, mi paki vice fiksa vir. Trǣ kibi multa ok, sur ðū īnfāno kæŭze. Om ene modō sekvanta proksimumecō, ānÞ sh tiele hiper defīnītive.
+    </p>
+  </div>,
+  <footer
+    style={
+      Object {
+        "height": 2000,
+      }
+    }
+  />,
+]
+`;
+
+exports[`Storyshots Core/Sticky Header With offset 1`] = `
+Array [
+  <div
+    style={
+      Object {
+        "border": "1px solid red",
+        "height": 2000,
+        "position": "relative",
+      }
+    }
+  >
+    <div>
+      <h1>
+        Title
+      </h1>
+      <div
+        className="sticky-header"
+        style={
+          Object {
+            "minHeight": "auto",
+          }
+        }
+      >
+        <div
+          className="sticky-header__children-wrapper"
+          style={
+            Object {
+              "top": 20,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "backgroundColor": "white",
+                "borderBottom": "1px solid black",
+                "height": 30,
+              }
+            }
+          >
+            Sticky header child
+          </div>
+        </div>
+      </div>
+      <h2>
+        Section title
+      </h2>
+      <p>
+        Ik kie neġi æpude pōsÞpriskribo, anċ ēg tiel subtegmenÞo. Giga gārði esperǣntigo vi jes. Ċit plēj esceptīnte hu, ōl vola eksploðæ poǽ. Ōīð gh pǽƿjo s'joro pronomeċa, mi paki vice fiksa vir. Trǣ kibi multa ok, sur ðū īnfāno kæŭze. Om ene modō sekvanta proksimumecō, ānÞ sh tiele hiper defīnītive.
+      </p>
+    </div>
+  </div>,
+  <footer
+    style={
+      Object {
+        "height": 2000,
+      }
+    }
+  />,
+]
+`;
+
+exports[`Storyshots Core/Sticky Header With shadow on scroll up 1`] = `
+<div
+  style={
+    Object {
+      "border": "1px solid red",
+      "height": 2000,
+      "position": "relative",
+    }
+  }
+>
+  <div>
+    <h1>
+      Title
+    </h1>
+    <div
+      className="sticky-header"
+      style={
+        Object {
+          "minHeight": "auto",
+        }
+      }
+    >
+      <div
+        className="sticky-header__children-wrapper"
+        style={
+          Object {
+            "top": 0,
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "backgroundColor": "white",
+              "borderBottom": "1px solid black",
+              "boxShadow": "none",
+              "height": 30,
+              "transition": "box-shadow 0.5s",
+            }
+          }
+        >
+          Sticky header child
+        </div>
+      </div>
+    </div>
+    <h2>
+      Section title
+    </h2>
+    <p>
+      Ik kie neġi æpude pōsÞpriskribo, anċ ēg tiel subtegmenÞo. Giga gārði esperǣntigo vi jes. Ċit plēj esceptīnte hu, ōl vola eksploðæ poǽ. Ōīð gh pǽƿjo s'joro pronomeċa, mi paki vice fiksa vir. Trǣ kibi multa ok, sur ðū īnfāno kæŭze. Om ene modō sekvanta proksimumecō, ānÞ sh tiele hiper defīnītive.
+    </p>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Core/Sticky Header With single child element 1`] = `
+Array [
+  <div
+    style={
+      Object {
+        "border": "1px solid red",
+        "height": 2000,
+        "position": "relative",
+      }
+    }
+  >
+    <div>
+      <h1>
+        Title
+      </h1>
+      <div
+        className="sticky-header"
+        style={
+          Object {
+            "minHeight": "auto",
+          }
+        }
+      >
+        <div
+          className="sticky-header__children-wrapper"
+          style={
+            Object {
+              "top": 0,
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "backgroundColor": "white",
+                "borderBottom": "1px solid black",
+                "height": 30,
+              }
+            }
+          >
+            Sticky header child
+          </div>
+        </div>
+      </div>
+      <h2>
+        Section title
+      </h2>
+      <p>
+        Ik kie neġi æpude pōsÞpriskribo, anċ ēg tiel subtegmenÞo. Giga gārði esperǣntigo vi jes. Ċit plēj esceptīnte hu, ōl vola eksploðæ poǽ. Ōīð gh pǽƿjo s'joro pronomeċa, mi paki vice fiksa vir. Trǣ kibi multa ok, sur ðū īnfāno kæŭze. Om ene modō sekvanta proksimumecō, ānÞ sh tiele hiper defīnītive.
+      </p>
+    </div>
+  </div>,
+  <footer
+    style={
+      Object {
+        "height": 2000,
+      }
+    }
+  />,
+]
+`;
+
 exports[`Storyshots Core/Story Topper Example 1`] = `
 <div
   className="story-topper"

--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -7496,7 +7496,7 @@ Array [
       <h1>
         Title
       </h1>
-      <div
+      <header
         className="sticky-header"
         style={
           Object {
@@ -7536,7 +7536,7 @@ Array [
             Sticky header child 2
           </div>
         </div>
-      </div>
+      </header>
       <h2>
         Section title
       </h2>
@@ -7573,7 +7573,7 @@ Array [
     <h1>
       Title
     </h1>
-    <div
+    <header
       className="sticky-header"
       style={
         Object {
@@ -7601,7 +7601,7 @@ Array [
           Sticky header child
         </div>
       </div>
-    </div>
+    </header>
     <h2>
       Section title
     </h2>
@@ -7634,7 +7634,7 @@ Array [
       <h1>
         Title
       </h1>
-      <div
+      <header
         className="sticky-header"
         style={
           Object {
@@ -7662,7 +7662,7 @@ Array [
             Sticky header child
           </div>
         </div>
-      </div>
+      </header>
       <h2>
         Section title
       </h2>
@@ -7695,7 +7695,7 @@ exports[`Storyshots Core/Sticky Header With shadow on scroll up 1`] = `
     <h1>
       Title
     </h1>
-    <div
+    <header
       className="sticky-header"
       style={
         Object {
@@ -7725,7 +7725,7 @@ exports[`Storyshots Core/Sticky Header With shadow on scroll up 1`] = `
           Sticky header child
         </div>
       </div>
-    </div>
+    </header>
     <h2>
       Section title
     </h2>
@@ -7751,7 +7751,7 @@ Array [
       <h1>
         Title
       </h1>
-      <div
+      <header
         className="sticky-header"
         style={
           Object {
@@ -7779,7 +7779,7 @@ Array [
             Sticky header child
           </div>
         </div>
-      </div>
+      </header>
       <h2>
         Section title
       </h2>

--- a/src/sticky-header/index.js
+++ b/src/sticky-header/index.js
@@ -5,9 +5,9 @@ import { Context } from '../article-layout';
 import useScrollPosition from './useScrollPosition';
 import './styles.scss';
 
-const StickyHeader = ({ children, containerRef, height, alwaysShowShadowWhenSticky }) => {
+const StickyHeader = ({ children, containerRef, height }) => {
   const [isSticky, setSticky] = useState(false);
-  const [stickyShadow, setStickyShadow] = useState(false);
+  const [scrollDirection, setScrollDirection] = useState('down');
   const ref = useRef(null);
 
   useScrollPosition(({ prevPos, currPos }) => {
@@ -17,8 +17,7 @@ const StickyHeader = ({ children, containerRef, height, alwaysShowShadowWhenStic
       const isSticky = stickyTop <= 0 && containerBottom - stickyHeight >= 0;
 
       setSticky(isSticky);
-      // Only show shadow when scrolling up
-      if (isSticky) setStickyShadow(alwaysShowShadowWhenSticky || currPos.y > prevPos.y);
+      setScrollDirection(currPos.y > prevPos.y ? 'up' : 'down');
     }
   }, []);
 
@@ -29,8 +28,6 @@ const StickyHeader = ({ children, containerRef, height, alwaysShowShadowWhenStic
   const wrapperClasses = classNames(
     'sticky-header-wrapper',
     isSticky && 'sticky-header-wrapper--fixed',
-    // Always show shadow on mobile
-    stickyShadow && isSticky && 'sticky-header-wrapper--shadow',
   );
 
   return (
@@ -39,14 +36,14 @@ const StickyHeader = ({ children, containerRef, height, alwaysShowShadowWhenStic
       ref={ref}
       style={{ minHeight: isSticky && breakpointHeight ? breakpointHeight : 'auto' }}
     >
-      {children}
+      {typeof children === 'function' ? children({ isSticky, scrollDirection }) : children}
     </div>
   );
 };
 
 StickyHeader.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.func.isRequired, PropTypes.node]).isRequired,
   height: PropTypes.object.isRequired,
-  alwaysShowShadow: PropTypes.bool,
   containerRef: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
@@ -54,7 +51,6 @@ StickyHeader.propTypes = {
 };
 
 StickyHeader.defaultProps = {
-  alwaysShowShadow: false,
   height: { default: 0, s: 0, m: 0, l: 0, xl: 0 },
 };
 

--- a/src/sticky-header/index.js
+++ b/src/sticky-header/index.js
@@ -1,46 +1,43 @@
 import React, { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { Context } from '../article-layout';
 import useScrollPosition from './useScrollPosition';
 import './styles.scss';
 
-const StickyHeader = ({ children, containerRef }) => {
+const StickyHeader = ({ children, containerRef, offset }) => {
   const [isSticky, setSticky] = useState(false);
   const [heightOfChildren, setHeightOfChildren] = useState(0);
   const [scrollDirection, setScrollDirection] = useState('down');
-  const ref = useRef(null);
+  const stickyRef = useRef(null);
   const childrenRef = useRef(null);
 
   useScrollPosition(({ prevPos, currPos }) => {
-    if (ref.current && containerRef.current) {
-      const { top: stickyTop, height: stickyHeight } = ref.current.getBoundingClientRect();
+    if (stickyRef.current && containerRef.current && childrenRef.current) {
       const { bottom: containerBottom } = containerRef.current.getBoundingClientRect();
-      const isSticky = stickyTop <= 0 && containerBottom - stickyHeight >= 0;
+      const { top: stickyTop, height: stickyHeight } = stickyRef.current.getBoundingClientRect();
+      const { height: heightOfChildren } = childrenRef.current.getBoundingClientRect();
 
-      if (childrenRef.current) {
-        const { height } = childrenRef.current.getBoundingClientRect();
-        setHeightOfChildren(height);
-      } else {
-        setHeightOfChildren(stickyHeight);
-      }
+      const isSticky = stickyTop <= offset && containerBottom - stickyHeight - offset >= 0;
 
+      setHeightOfChildren(heightOfChildren);
       setSticky(isSticky);
       setScrollDirection(currPos.y > prevPos.y ? 'up' : 'down');
     }
   }, []);
 
-  const wrapperClasses = classNames('sticky-header', isSticky && 'sticky-header--fixed');
+  const stickyHeaderClasses = classNames('sticky-header', isSticky && 'sticky-header--fixed');
 
   const childrenIsFunction = typeof children === 'function';
 
   return (
     <div
-      className={wrapperClasses}
-      ref={ref}
+      className={stickyHeaderClasses}
+      ref={stickyRef}
       style={{ minHeight: isSticky ? heightOfChildren : 'auto' }}
     >
-      {childrenIsFunction ? children({ isSticky, scrollDirection, ref: childrenRef }) : children}
+      <div className="sticky-header__children-wrapper" ref={childrenRef} style={{ top: offset }}>
+        {childrenIsFunction ? children({ isSticky, scrollDirection }) : children}
+      </div>
     </div>
   );
 };
@@ -51,6 +48,11 @@ StickyHeader.propTypes = {
     PropTypes.func,
     PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
   ]).isRequired,
+  offset: PropTypes.number,
+};
+
+StickyHeader.defaultProps = {
+  offset: 0,
 };
 
 export default StickyHeader;

--- a/src/sticky-header/index.js
+++ b/src/sticky-header/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import useScrollPosition from './useScrollPosition';
@@ -35,7 +35,7 @@ const StickyHeader = ({ children, containerRef, offset }) => {
   const childrenIsFunction = typeof children === 'function';
 
   return (
-    <div
+    <header
       className={stickyHeaderClasses}
       ref={stickyRef}
       style={{ minHeight: isSticky ? heightOfChildren : 'auto' }}
@@ -43,7 +43,7 @@ const StickyHeader = ({ children, containerRef, offset }) => {
       <div className="sticky-header__children-wrapper" ref={childrenRef} style={{ top: offset }}>
         {childrenIsFunction ? children({ isSticky, scrollDirection }) : children}
       </div>
-    </div>
+    </header>
   );
 };
 

--- a/src/sticky-header/index.js
+++ b/src/sticky-header/index.js
@@ -12,12 +12,17 @@ const StickyHeader = ({ children, containerRef, offset }) => {
   const childrenRef = useRef(null);
 
   useScrollPosition(({ prevPos, currPos }) => {
-    if (stickyRef.current && containerRef.current && childrenRef.current) {
-      const { bottom: containerBottom } = containerRef.current.getBoundingClientRect();
+    if (stickyRef.current && childrenRef.current) {
       const { top: stickyTop, height: stickyHeight } = stickyRef.current.getBoundingClientRect();
       const { height: heightOfChildren } = childrenRef.current.getBoundingClientRect();
 
-      const isSticky = stickyTop <= offset && containerBottom - stickyHeight - offset >= 0;
+      let isSticky;
+      if (containerRef?.current) {
+        const { bottom: containerBottom } = containerRef.current.getBoundingClientRect();
+        isSticky = stickyTop <= offset && containerBottom - stickyHeight - offset >= 0;
+      } else {
+        isSticky = stickyTop <= offset;
+      }
 
       setHeightOfChildren(heightOfChildren);
       setSticky(isSticky);
@@ -47,7 +52,7 @@ StickyHeader.propTypes = {
   containerRef: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
-  ]).isRequired,
+  ]),
   offset: PropTypes.number,
 };
 

--- a/src/sticky-header/index.js
+++ b/src/sticky-header/index.js
@@ -1,0 +1,61 @@
+import React, { useState, useRef, useContext } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { Context } from '../article-layout';
+import useScrollPosition from './useScrollPosition';
+import './styles.scss';
+
+const StickyHeader = ({ children, containerRef, height, alwaysShowShadowWhenSticky }) => {
+  const [isSticky, setSticky] = useState(false);
+  const [stickyShadow, setStickyShadow] = useState(false);
+  const ref = useRef(null);
+
+  useScrollPosition(({ prevPos, currPos }) => {
+    if (ref.current && containerRef.current) {
+      const { top: stickyTop, height: stickyHeight } = ref.current.getBoundingClientRect();
+      const { bottom: containerBottom } = containerRef.current.getBoundingClientRect();
+      const isSticky = stickyTop <= 0 && containerBottom - stickyHeight >= 0;
+
+      setSticky(isSticky);
+      // Only show shadow when scrolling up
+      if (isSticky) setStickyShadow(alwaysShowShadowWhenSticky || currPos.y > prevPos.y);
+    }
+  }, []);
+
+  const { b } = useContext(Context);
+  const breakpoint = (b && b.breakpoint) || 'default';
+  const breakpointHeight = height[breakpoint];
+
+  const wrapperClasses = classNames(
+    'sticky-header-wrapper',
+    isSticky && 'sticky-header-wrapper--fixed',
+    // Always show shadow on mobile
+    stickyShadow && isSticky && 'sticky-header-wrapper--shadow',
+  );
+
+  return (
+    <div
+      className={wrapperClasses}
+      ref={ref}
+      style={{ minHeight: isSticky && breakpointHeight ? breakpointHeight : 'auto' }}
+    >
+      {children}
+    </div>
+  );
+};
+
+StickyHeader.propTypes = {
+  height: PropTypes.object.isRequired,
+  alwaysShowShadow: PropTypes.bool,
+  containerRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]).isRequired,
+};
+
+StickyHeader.defaultProps = {
+  alwaysShowShadow: false,
+  height: { default: 0, s: 0, m: 0, l: 0, xl: 0 },
+};
+
+export default StickyHeader;

--- a/src/sticky-header/index.stories.mdx
+++ b/src/sticky-header/index.stories.mdx
@@ -52,7 +52,7 @@ TKTK
 </Canvas>
 
 <Canvas>
-  <Story name="With shadow always on when sticky">
+  <Story name="With shadow on scroll up">
     <StickyHeaderStoryContainer>
       {({ containerRef }) => (
         <div>
@@ -60,11 +60,23 @@ TKTK
           <StickyHeader
             containerRef={containerRef}
             height={{ default: 30, s: 30, m: 30, l: 30, xl: 30 }}
-            alwaysShowShadowWhenSticky
           >
-            <div style={{ height: 30, backgroundColor: 'white', borderBottom: '1px solid black' }}>
-              Sticky header child
-            </div>
+            {({ isSticky, scrollDirection }) => (
+              <div
+                style={{
+                  height: 30,
+                  backgroundColor: 'white',
+                  borderBottom: '1px solid black',
+                  transition: 'box-shadow 0.5s',
+                  boxShadow:
+                    isSticky && scrollDirection === 'up'
+                      ? '0 4px 6px 0 rgba(77, 72, 69, 0.1), 0 1px 2px 0 rgba(77, 72, 69, 0.24'
+                      : 'none',
+                }}
+              >
+                Sticky header child
+              </div>
+            )}
           </StickyHeader>
           <ExampleContent />
         </div>

--- a/src/sticky-header/index.stories.mdx
+++ b/src/sticky-header/index.stories.mdx
@@ -34,14 +34,28 @@ export const StickyHeaderStoryContainer = ({ height, children }) => {
 `<StickyHeader>{children}</StickyHeader>` can be used to turn any React node or component
 into a sticky header - a header which fixes into place after the top (+ optional offset) of the page reaches the header
 and becomes unfixed after it has passed the bottom of a container element (e.g. the main body of a page).
+It does not rely on the css `position: sticky`.
 
 Props:
 
-- `containerRef` (ref created with `createRef` or `useRef`): a ref to a container element.
-  The sticky header will become hidden after the bottom of the header has passed the bottom of the container
+- `containerRef` (ref created with `createRef` or `useRef` - optional): a ref to a container element.
+  The sticky header will become hidden after the bottom of the header has passed the bottom of the container. If
+  missing the header will remain fixed all the way to the bottom of the page
 - `offset` (integer - optional): a pixel offset for when the header should become sticky - this offset is also applied
   to the fixed position of the header (i.e. if set to 20px, the header will become sticky when the top of the page is
   20px above the header and the header will be in a fixed position 20px below the top of the page)
+
+The component passes two props to the child component if needed. These can be accessed by passing
+the following as a child:
+
+```
+{({ isSticky, scrollDirection }) => (
+  ... use the props here ...
+)}
+```
+
+- `isSticky` (boolean): whether or not the sticky header is currently fixed in place
+- `scrollDirection` ('up' or 'down'): the direction the user is scrolling in
 
 <Canvas>
   <Story name="With single child element">
@@ -139,6 +153,21 @@ Props:
         </div>
       )}
     </StickyHeaderStoryContainer>
+    <footer style={{ height: 2000 }}></footer>
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story name="With missing containerRef">
+    <div>
+      <h1>Title</h1>
+      <StickyHeader>
+        <div style={{ height: 30, backgroundColor: 'white', borderBottom: '1px solid black' }}>
+          Sticky header child
+        </div>
+      </StickyHeader>
+      <ExampleContent />
+    </div>
     <footer style={{ height: 2000 }}></footer>
   </Story>
 </Canvas>

--- a/src/sticky-header/index.stories.mdx
+++ b/src/sticky-header/index.stories.mdx
@@ -1,7 +1,10 @@
-import { Fragment, useRef } from 'react';
+import { Fragment, useRef, useState } from 'react';
 import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { withKnobs, boolean } from '@storybook/addon-knobs';
 import '../shared/critical-path.scss';
 import StickyHeader from './';
+
+export const hideElement = (hideElement) => boolean('Hide element', hideElement);
 
 export const ExampleContent = () => (
   <Fragment>
@@ -24,7 +27,7 @@ export const StickyHeaderStoryContainer = ({ children }) => {
   );
 };
 
-<Meta title="Core/Sticky Header" component={StickyHeader} />
+<Meta title="Core/Sticky Header" component={StickyHeader} decorators={[withKnobs]} />
 
 # Sticky header component
 
@@ -36,10 +39,7 @@ TKTK
       {({ containerRef }) => (
         <div>
           <h1>Title</h1>
-          <StickyHeader
-            containerRef={containerRef}
-            height={{ default: 30, s: 30, m: 30, l: 30, xl: 30 }}
-          >
+          <StickyHeader containerRef={containerRef}>
             <div style={{ height: 30, backgroundColor: 'white', borderBottom: '1px solid black' }}>
               Sticky header child
             </div>
@@ -57,10 +57,7 @@ TKTK
       {({ containerRef }) => (
         <div>
           <h1>Title</h1>
-          <StickyHeader
-            containerRef={containerRef}
-            height={{ default: 30, s: 30, m: 30, l: 30, xl: 30 }}
-          >
+          <StickyHeader containerRef={containerRef}>
             {({ isSticky, scrollDirection }) => (
               <div
                 style={{
@@ -78,6 +75,42 @@ TKTK
               </div>
             )}
           </StickyHeader>
+          <ExampleContent />
+        </div>
+      )}
+    </StickyHeaderStoryContainer>
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story name="With changing height of children">
+    <StickyHeaderStoryContainer>
+      {({ containerRef }) => (
+        <div>
+          <h1>Title</h1>
+          <StickyHeader containerRef={containerRef}>
+            {({ ref }) => (
+              <div ref={ref}>
+                <div
+                  style={{ height: 30, backgroundColor: 'white', borderBottom: '1px solid black' }}
+                >
+                  Sticky header child
+                </div>
+                <div
+                  style={{
+                    height: 30,
+                    backgroundColor: 'yellow',
+                    borderBottom: '1px solid black',
+                    display: hideElement(false) ? 'none' : 'block',
+                  }}
+                >
+                  Sticky header child 2
+                </div>
+              </div>
+            )}
+          </StickyHeader>
+          <ExampleContent />
+          <ExampleContent />
           <ExampleContent />
         </div>
       )}

--- a/src/sticky-header/index.stories.mdx
+++ b/src/sticky-header/index.stories.mdx
@@ -18,10 +18,10 @@ export const ExampleContent = () => (
   </Fragment>
 );
 
-export const StickyHeaderStoryContainer = ({ children }) => {
+export const StickyHeaderStoryContainer = ({ height, children }) => {
   const containerRef = useRef();
   return (
-    <div ref={containerRef} style={{ height: 3000, position: 'relative' }}>
+    <div ref={containerRef} style={{ height, position: 'relative', border: '1px solid red' }}>
       {children({ containerRef })}
     </div>
   );
@@ -31,11 +31,21 @@ export const StickyHeaderStoryContainer = ({ children }) => {
 
 # Sticky header component
 
-TKTK
+`<StickyHeader>{children}</StickyHeader>` can be used to turn any React node or component
+into a sticky header - a header which fixes into place after the top (+ optional offset) of the page reaches the header
+and becomes unfixed after it has passed the bottom of a container element (e.g. the main body of a page).
+
+Props:
+
+- `containerRef` (ref created with `createRef` or `useRef`): a ref to a container element.
+  The sticky header will become hidden after the bottom of the header has passed the bottom of the container
+- `offset` (integer - optional): a pixel offset for when the header should become sticky - this offset is also applied
+  to the fixed position of the header (i.e. if set to 20px, the header will become sticky when the top of the page is
+  20px above the header and the header will be in a fixed position 20px below the top of the page)
 
 <Canvas>
   <Story name="With single child element">
-    <StickyHeaderStoryContainer>
+    <StickyHeaderStoryContainer height={2000}>
       {({ containerRef }) => (
         <div>
           <h1>Title</h1>
@@ -48,12 +58,32 @@ TKTK
         </div>
       )}
     </StickyHeaderStoryContainer>
+    <footer style={{ height: 2000 }}></footer>
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story name="With offset">
+    <StickyHeaderStoryContainer height={2000}>
+      {({ containerRef }) => (
+        <div>
+          <h1>Title</h1>
+          <StickyHeader containerRef={containerRef} offset={20}>
+            <div style={{ height: 30, backgroundColor: 'white', borderBottom: '1px solid black' }}>
+              Sticky header child
+            </div>
+          </StickyHeader>
+          <ExampleContent />
+        </div>
+      )}
+    </StickyHeaderStoryContainer>
+    <footer style={{ height: 2000 }}></footer>
   </Story>
 </Canvas>
 
 <Canvas>
   <Story name="With shadow on scroll up">
-    <StickyHeaderStoryContainer>
+    <StickyHeaderStoryContainer height={2000}>
       {({ containerRef }) => (
         <div>
           <h1>Title</h1>
@@ -84,30 +114,24 @@ TKTK
 
 <Canvas>
   <Story name="With changing height of children">
-    <StickyHeaderStoryContainer>
+    <StickyHeaderStoryContainer height={2000}>
       {({ containerRef }) => (
         <div>
           <h1>Title</h1>
           <StickyHeader containerRef={containerRef}>
-            {({ ref }) => (
-              <div ref={ref}>
-                <div
-                  style={{ height: 30, backgroundColor: 'white', borderBottom: '1px solid black' }}
-                >
-                  Sticky header child
-                </div>
-                <div
-                  style={{
-                    height: 30,
-                    backgroundColor: 'yellow',
-                    borderBottom: '1px solid black',
-                    display: hideElement(false) ? 'none' : 'block',
-                  }}
-                >
-                  Sticky header child 2
-                </div>
-              </div>
-            )}
+            <div style={{ height: 30, backgroundColor: 'white', borderBottom: '1px solid black' }}>
+              Sticky header child
+            </div>
+            <div
+              style={{
+                height: 30,
+                backgroundColor: 'yellow',
+                borderBottom: '1px solid black',
+                display: hideElement(false) ? 'none' : 'block',
+              }}
+            >
+              Sticky header child 2
+            </div>
           </StickyHeader>
           <ExampleContent />
           <ExampleContent />
@@ -115,5 +139,6 @@ TKTK
         </div>
       )}
     </StickyHeaderStoryContainer>
+    <footer style={{ height: 2000 }}></footer>
   </Story>
 </Canvas>

--- a/src/sticky-header/index.stories.mdx
+++ b/src/sticky-header/index.stories.mdx
@@ -1,0 +1,74 @@
+import { Fragment, useRef } from 'react';
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import '../shared/critical-path.scss';
+import StickyHeader from './';
+
+export const ExampleContent = () => (
+  <Fragment>
+    <h2>Section title</h2>
+    <p>
+      Ik kie neġi æpude pōsÞpriskribo, anċ ēg tiel subtegmenÞo. Giga gārði esperǣntigo vi jes. Ċit
+      plēj esceptīnte hu, ōl vola eksploðæ poǽ. Ōīð gh pǽƿjo s&apos;joro pronomeċa, mi paki vice
+      fiksa vir. Trǣ kibi multa ok, sur ðū īnfāno kæŭze. Om ene modō sekvanta proksimumecō, ānÞ sh
+      tiele hiper defīnītive.
+    </p>
+  </Fragment>
+);
+
+export const StickyHeaderStoryContainer = ({ children }) => {
+  const containerRef = useRef();
+  return (
+    <div ref={containerRef} style={{ height: 3000, position: 'relative' }}>
+      {children({ containerRef })}
+    </div>
+  );
+};
+
+<Meta title="Core/Sticky Header" component={StickyHeader} />
+
+# Sticky header component
+
+TKTK
+
+<Canvas>
+  <Story name="With single child element">
+    <StickyHeaderStoryContainer>
+      {({ containerRef }) => (
+        <div>
+          <h1>Title</h1>
+          <StickyHeader
+            containerRef={containerRef}
+            height={{ default: 30, s: 30, m: 30, l: 30, xl: 30 }}
+          >
+            <div style={{ height: 30, backgroundColor: 'white', borderBottom: '1px solid black' }}>
+              Sticky header child
+            </div>
+          </StickyHeader>
+          <ExampleContent />
+        </div>
+      )}
+    </StickyHeaderStoryContainer>
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story name="With shadow always on when sticky">
+    <StickyHeaderStoryContainer>
+      {({ containerRef }) => (
+        <div>
+          <h1>Title</h1>
+          <StickyHeader
+            containerRef={containerRef}
+            height={{ default: 30, s: 30, m: 30, l: 30, xl: 30 }}
+            alwaysShowShadowWhenSticky
+          >
+            <div style={{ height: 30, backgroundColor: 'white', borderBottom: '1px solid black' }}>
+              Sticky header child
+            </div>
+          </StickyHeader>
+          <ExampleContent />
+        </div>
+      )}
+    </StickyHeaderStoryContainer>
+  </Story>
+</Canvas>

--- a/src/sticky-header/styles.scss
+++ b/src/sticky-header/styles.scss
@@ -1,0 +1,22 @@
+@import 'o-grid/main.scss';
+$sticky-box-shadow: 0 4px 6px 0 rgba(77, 72, 69, 0.1), 0 1px 2px 0 rgba(77, 72, 69, 0.24);
+
+.sticky-header-wrapper {
+  &--fixed {
+    > * {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      z-index: 1;
+      box-shadow: none;
+      transition: box-shadow 0.5s;
+    }
+  }
+
+  &--shadow {
+    > * {
+      box-shadow: $sticky-box-shadow;
+    }
+  }
+}

--- a/src/sticky-header/styles.scss
+++ b/src/sticky-header/styles.scss
@@ -1,6 +1,6 @@
 @import 'o-grid/main.scss';
 
-.sticky-header-wrapper {
+.sticky-header {
   &--fixed {
     > * {
       position: fixed;

--- a/src/sticky-header/styles.scss
+++ b/src/sticky-header/styles.scss
@@ -1,5 +1,4 @@
 @import 'o-grid/main.scss';
-$sticky-box-shadow: 0 4px 6px 0 rgba(77, 72, 69, 0.1), 0 1px 2px 0 rgba(77, 72, 69, 0.24);
 
 .sticky-header-wrapper {
   &--fixed {
@@ -9,14 +8,6 @@ $sticky-box-shadow: 0 4px 6px 0 rgba(77, 72, 69, 0.1), 0 1px 2px 0 rgba(77, 72, 
       left: 0;
       right: 0;
       z-index: 1;
-      box-shadow: none;
-      transition: box-shadow 0.5s;
-    }
-  }
-
-  &--shadow {
-    > * {
-      box-shadow: $sticky-box-shadow;
     }
   }
 }

--- a/src/sticky-header/styles.scss
+++ b/src/sticky-header/styles.scss
@@ -1,13 +1,7 @@
-@import 'o-grid/main.scss';
-
-.sticky-header {
-  &--fixed {
-    > * {
-      position: fixed;
-      top: 0;
-      left: 0;
-      right: 0;
-      z-index: 1;
-    }
-  }
+.sticky-header--fixed .sticky-header__children-wrapper {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1;
 }

--- a/src/sticky-header/useScrollPosition.js
+++ b/src/sticky-header/useScrollPosition.js
@@ -1,0 +1,46 @@
+// From: https://dev.to/n8tb1t/tracking-scroll-position-with-react-hooks-3bbj
+import { useRef, useLayoutEffect } from 'react';
+
+const isBrowser = typeof window !== `undefined`;
+
+const getScrollPosition = ({ element, useWindow }) => {
+  if (!isBrowser) return { x: 0, y: 0 };
+
+  const target = element ? element.current : document.body;
+  const position = target.getBoundingClientRect();
+
+  return useWindow
+    ? { x: window.scrollX, y: window.scrollY }
+    : { x: position.left, y: position.top };
+};
+
+const useScrollPosition = (effect, deps, element, useWindow, wait) => {
+  const position = useRef(getScrollPosition({ useWindow }));
+
+  let throttleTimeout = null;
+
+  const callBack = () => {
+    const currPos = getScrollPosition({ element, useWindow });
+    effect({ prevPos: position.current, currPos });
+    position.current = currPos;
+    throttleTimeout = null;
+  };
+
+  useLayoutEffect(() => {
+    const handleScroll = () => {
+      if (wait) {
+        if (throttleTimeout === null) {
+          throttleTimeout = setTimeout(callBack, wait);
+        }
+      } else {
+        callBack();
+      }
+    };
+
+    window.addEventListener('scroll', handleScroll);
+
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, deps);
+};
+
+export default useScrollPosition;


### PR DESCRIPTION
A sticky header component which doesn't rely on `position: sticky`
- Supports pixel offset
- Hiding after end of container (e.g. the end of `<main></main>`)
- Exposes `scrollDirection` and `isSticky` which can be used to conditionally style the header