### PR TITLE
Add aria labels for AutosuggestSearch

### DIFF
--- a/src/autosuggest-search/index.js
+++ b/src/autosuggest-search/index.js
@@ -34,9 +34,10 @@ const defaultGetSuggestionValue = ({ display }) => display;
 
 const SelectedValue = ({ className, display, value, onSelectedValueRemove }) => (
   <div className={`${className}__selected-value`} key={`selected-value__${value}`}>
-    <span>{display}</span>
+    <span id={`selected-value__${value}`}>{display}</span>
     <button
       className={`${className}__selected-value-close-button`}
+      aria-labelledby={`selected-value__${value}`}
       type="button"
       onClick={() => onSelectedValueRemove(value)}
     >
@@ -228,6 +229,7 @@ const AutosuggestSearch = ({
           }}
           focusInputOnSuggestionClick={usingSelectedValues}
           inputProps={{
+            'aria-label': placeholder,
             placeholder,
             value: searchValue,
             onChange,


### PR DESCRIPTION
Adds aria labels for buttons in the AutosuggestSearch component. This fixes several of the errors that pa11y picks up (you can see the errors in the vaccine tracker project), but it doesn't fix one around having a submit button in the form. Not sure what to do about that off the top of my head, but figured this was at least a good first step. 