### PR TITLE
Update o-table to 8.1.5 to get updated updateRows function which will…

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@financial-times/o-normalise": "^2.0.3",
     "@financial-times/o-overlay": "^3.0.4",
     "@financial-times/o-share": "^7.4.1",
-    "@financial-times/o-table": "^8.0.9",
+    "@financial-times/o-table": "^8.1.5",
     "@financial-times/o-teaser": "^5.1.0",
     "@financial-times/o-tracking": "^2.0.8",
     "@financial-times/o-typography": "^6.3.5",


### PR DESCRIPTION
… fix issue with ig-vaccine-tracker

context: https://financialtimes.slack.com/archives/C02FU5ARJ/p1621271766138200

related PR: https://github.com/Financial-Times/o-table/pull/252