### PR TITLE
Allow ability to pass in a scroll depth target

### DIFF
--- a/src/analytics/index.js
+++ b/src/analytics/index.js
@@ -12,7 +12,7 @@ import { spoorTrackingPixel } from '../shared/helpers';
 // Disables warning for dangerouslySetInnerHTML because we kiiiiinda need it here.
 /* eslint-disable react/no-danger */
 
-const Analytics = ({ id, tracking, flags }) => {
+const Analytics = ({ id, tracking, flags, scrollDepthTarget }) => {
   useEffect(() => {
     (async () => {
       try {
@@ -60,7 +60,7 @@ const Analytics = ({ id, tracking, flags }) => {
         oTracking.click.init();
 
         // Attention tracking
-        nTracking.trackers.pageAttention();
+        nTracking.trackers.pageAttention({ target: scrollDepthTarget });
       } catch (e) {
         console.error(e);
       }
@@ -132,12 +132,14 @@ Analytics.propTypes = {
   tracking: PropTypes.shape({
     micrositeName: PropTypes.string,
   }),
+  scrollDepthTarget: PropTypes.string,
 };
 
 Analytics.defaultProps = {
   tracking: {
     micrositeName: undefined,
   },
+  scrollDepthTarget: '.article-body'
 };
 
 export default Analytics;

--- a/src/analytics/index.stories.mdx
+++ b/src/analytics/index.stories.mdx
@@ -14,7 +14,7 @@ You need to just simply import it where-ever.
   <Story name="Example" parameters={{ chromatic: { disable: true } }}>
     <>
       <h4>You won&apos;t see anything here as &quot;Analytics&quot; has no visual output</h4>,
-      <Analytics id="e8e6e017-d06b-3cfa-8cb6-0b9e30bc847e" flags={props.flags} />
+      <Analytics id="e8e6e017-d06b-3cfa-8cb6-0b9e30bc847e" flags={props.flags} scrollDepthTarget="body" />
     </>
   </Story>
 </Canvas>


### PR DESCRIPTION
Add prop to pass in container for scroll depth calculations to target – defaults to `.article-body` for starter-kit but can be changed by passing the prop through `Layout` for different page configurations