### PR TITLE
Remove duplicated page and click event tracking

### DIFF
--- a/src/analytics/index.js
+++ b/src/analytics/index.js
@@ -49,15 +49,10 @@ const Analytics = ({ id, tracking, flags, scrollDepthTarget }) => {
           ...pageData,
         }
 
+        // n-tracking's init function sets up page view and click event tracking
         const oTracking = nTracking.init({
           appContext,
         });
-
-        // Page
-        oTracking.page(pageData);
-
-        // Links
-        oTracking.click.init();
 
         // Attention tracking
         nTracking.trackers.pageAttention({ target: scrollDepthTarget });


### PR DESCRIPTION
I think we're currently duplicated page and click event tracking (see   http://ft-ig-content-prod.s3-website-eu-west-1.amazonaws.com/v2/ft-interactive/starter-kit/e37fc053ac9da1c04a7cc01dd7d0415571eae57d/ as an example) — I see the same page and click event bits in the init function within n-tracking itself: https://github.com/Financial-Times/n-tracking/blob/main/src/client/index.js#L33-L42

The only issue I see is that I don't see the page:view event being fired anymore within the storybook, so I'm not sure this is totally correct. But I'm thinking it might be because of the way storybook is set up and the conditional that's set up in n-tracking around `page:view`? I'm not sure though... thoughts? 

For reference, this is how FT.com uses `n-tracking` on article pages: https://github.com/Financial-Times/next-article/blob/main/client/main.js