### PR TITLE
Add custom flourish template analytics listener

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@financial-times/ads-legacy-o-ads": "^3.3.0",
+        "@financial-times/flourish-receive-custom-analytics": "^1.1.0",
         "@financial-times/format-number": "^1.0.0",
         "@financial-times/ft-date-format": "^2.1.0",
         "@financial-times/math": "^1.1.0",
@@ -2084,6 +2085,11 @@
       "peerDependencies": {
         "@financial-times/o-utils": "^2.0.0"
       }
+    },
+    "node_modules/@financial-times/flourish-receive-custom-analytics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/flourish-receive-custom-analytics/-/flourish-receive-custom-analytics-1.1.0.tgz",
+      "integrity": "sha512-3DuYeWjsB0N9ddk9iP/MOcJ6n8fzsf/Mv3Wknu8zMPp2jNjwHrdIE2kpcj2bJz9EUrWqXPHmJZ4covNo8pfahQ=="
     },
     "node_modules/@financial-times/format-number": {
       "version": "1.0.0",
@@ -26285,6 +26291,11 @@
         "@financial-times/o-utils": "^2.0.0",
         "@financial-times/o-viewport": "^5.0.0"
       }
+    },
+    "@financial-times/flourish-receive-custom-analytics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/flourish-receive-custom-analytics/-/flourish-receive-custom-analytics-1.1.0.tgz",
+      "integrity": "sha512-3DuYeWjsB0N9ddk9iP/MOcJ6n8fzsf/Mv3Wknu8zMPp2jNjwHrdIE2kpcj2bJz9EUrWqXPHmJZ4covNo8pfahQ=="
     },
     "@financial-times/format-number": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "@financial-times/ads-legacy-o-ads": "^3.3.0",
+    "@financial-times/flourish-receive-custom-analytics": "^1.1.0",
     "@financial-times/format-number": "^1.0.0",
     "@financial-times/ft-date-format": "^2.1.0",
     "@financial-times/math": "^1.1.0",

--- a/src/analytics/index.js
+++ b/src/analytics/index.js
@@ -5,6 +5,10 @@
 
 import React, { Fragment, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
+import core from '@financial-times/o-tracking/src/javascript/core';
+import { merge } from '@financial-times/o-tracking/src/javascript/utils';
+import { get } from '@financial-times/o-tracking/src/javascript/core/settings';
+import customFlourishAnalytics from '@financial-times/flourish-receive-custom-analytics';
 import { flagsPropType } from '../shared/proptypes';
 import { spoorTrackingPixel } from '../shared/helpers';
 
@@ -56,6 +60,12 @@ const Analytics = ({ id, tracking, flags, scrollDepthTarget }) => {
           // n-tracking's init function sets up page view and click event tracking
           const oTracking = nTracking.init({
             appContext,
+          });
+
+          customFlourishAnalytics.init((data) => {
+            // Merge the event data into the "parent" config data
+            const config = merge(get('config'), data);
+            core.track(config);
           });
 
           // Attention tracking


### PR DESCRIPTION
Initialises customFlourishAnalytics meaning that clicks and custom events send by the flourish-send-custom-analytics package from inside our custom flourish templates will be sent to spoor with the correct contextual / user / device etc data.

Sends click events to spoor which look like this for a click event:
<img width="769" alt="Screenshot 2022-06-09 at 14 49 19" src="https://user-images.githubusercontent.com/1282239/172863220-88b54a75-6b07-4c59-9a5e-33b366b6e0bf.png">

and like this for a custom event:
<img width="742" alt="Screenshot 2022-06-09 at 14 51 21" src="https://user-images.githubusercontent.com/1282239/172863614-fc5f7fcd-aba8-4695-9a16-35c03cb82b88.png">

