### PR TITLE
Update o-comments from v8 to v9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@financial-times/o-brand": "^4.2.1",
         "@financial-times/o-buttons": "^7.5.0",
         "@financial-times/o-colors": "^6.4.2",
-        "@financial-times/o-comments": "^8.3.0",
+        "@financial-times/o-comments": "^9.0.1",
         "@financial-times/o-date": "^5.2.0",
         "@financial-times/o-editorial-layout": "^2.3.0",
         "@financial-times/o-editorial-typography": "^2.3.0",
@@ -2206,9 +2206,9 @@
       }
     },
     "node_modules/@financial-times/o-comments": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-comments/-/o-comments-8.3.3.tgz",
-      "integrity": "sha512-HR016ifzx9WbmnlTemDQEmd+Uhy24DNpcptFRw4BsZSWXtQg2pEgftUsTTg4DYuaLGFHSLbDScZjsWVKCO4Rtw==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-comments/-/o-comments-9.0.1.tgz",
+      "integrity": "sha512-uwWtBHgovzlq5XNw0Ic8GJMAEpN1VnAuzlI9GFCK/1rWZQc/5tf4OV5f9OWSpLAh0jOqGGChTwzUlVUFoJr7Vg==",
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -26380,9 +26380,9 @@
       "requires": {}
     },
     "@financial-times/o-comments": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-comments/-/o-comments-8.3.3.tgz",
-      "integrity": "sha512-HR016ifzx9WbmnlTemDQEmd+Uhy24DNpcptFRw4BsZSWXtQg2pEgftUsTTg4DYuaLGFHSLbDScZjsWVKCO4Rtw==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-comments/-/o-comments-9.0.1.tgz",
+      "integrity": "sha512-uwWtBHgovzlq5XNw0Ic8GJMAEpN1VnAuzlI9GFCK/1rWZQc/5tf4OV5f9OWSpLAh0jOqGGChTwzUlVUFoJr7Vg==",
       "requires": {}
     },
     "@financial-times/o-date": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@financial-times/o-brand": "^4.2.1",
     "@financial-times/o-buttons": "^7.5.0",
     "@financial-times/o-colors": "^6.4.2",
-    "@financial-times/o-comments": "^8.3.0",
+    "@financial-times/o-comments": "^9.0.1",
     "@financial-times/o-date": "^5.2.0",
     "@financial-times/o-editorial-layout": "^2.3.0",
     "@financial-times/o-editorial-typography": "^2.3.0",

--- a/src/comments/styles.scss
+++ b/src/comments/styles.scss
@@ -1,3 +1,9 @@
-$o-comments-is-silent: false;
+$system-code: 'ig-content';
 @import '../shared/_globals.scss';
 @import '@financial-times/o-comments/main.scss';
+
+@include oComments(
+  $opts: (
+    'coral-talk-iframe': false,
+  )
+);


### PR DESCRIPTION
Update o-comments to v9 since v8 now doesn't apply stylings because of the Origami Build Service v2 deprecation. 