### PR TITLE
Fix SSR bug in PropTypes

### DIFF
--- a/src/navigation-header/dropdown.jsx
+++ b/src/navigation-header/dropdown.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 
 // 'Element' isn't available on the server, so we need a more generic return value for SSR builds
-const IsomorphicElement = typeof Element === 'undefined' ? () => ({}) : Element;
+const IsomorphicElement = typeof Element === 'undefined' ? Function : Element;
 
 const RefPropType = PropTypes.oneOfType([
   PropTypes.func,

--- a/src/navigation-header/dropdown.jsx
+++ b/src/navigation-header/dropdown.jsx
@@ -1,9 +1,12 @@
 import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 
+// 'Element' isn't available on the server, so we need a more generic return value for SSR builds
+const IsomorphicElement = typeof Element === 'undefined' ? () => ({}) : Element;
+
 const RefPropType = PropTypes.oneOfType([
   PropTypes.func,
-  PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  PropTypes.shape({ current: PropTypes.instanceOf(IsomorphicElement) }),
 ]);
 
 export const NavigationHeaderMobileDropdownButton = ({


### PR DESCRIPTION
I'm trying to get an upcoming starter-kit project to [pregenerate its HTML using Vite](https://vitejs.dev/guide/ssr) (much like how `react-snap` used to) - but I'm running into an error caused by an upstream use of browser-only globals inside `g-components`.

It seems that the NavigationHeader uses `Element` in its PropTypes checks — which throws an error when the component is used in the Node environment. As a quick fix, I've added a simple conditional check for the presence of that global, to fall back to an empty function (a shim for the Element constructor) on the server.

Another fix might be configuring the build step to remove _all_ PropTypes code in production builds for NPM - although I'm not immediately sure how to do that (or whether it's even desirable).

## Test Steps

- [x] Test in SSR project via `npm link`
- [ ] Ensure Storybook stories build and the component renders as expected

^ I'm currently running into an issue testing this - I get an error opening this component in Storybook, even on `main`. Have any of you seen this error before, or know what might be causing it?

<img width="1149" alt="Screenshot 2023-11-20 at 09 58 43" src="https://github.com/Financial-Times/g-components/assets/3749412/f2968269-b8f1-4e59-82e1-0def3f7bf2d8">
