### PR TITLE
Integrate cmp-client to get new cookie consent banner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@financial-times/ads-legacy-o-ads": "5.3.1",
-        "@financial-times/cmp-client": "^2.2.2",
+        "@financial-times/cmp-client": "^3.1.4",
         "@financial-times/flourish-receive-custom-analytics": "^1.2.0",
         "@financial-times/format-number": "^1.0.0",
         "@financial-times/ft-date-format": "^2.1.0",
@@ -2505,12 +2505,25 @@
       }
     },
     "node_modules/@financial-times/cmp-client": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@financial-times/cmp-client/-/cmp-client-2.2.2.tgz",
-      "integrity": "sha512-O9O3uWJ4q92JfxXXWvHlBLqA4jrgdd+RvycMz8y0VcECZLkikv9kfzKAi1DkavLfh65BTOedZgm+ddkyXYzNOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@financial-times/cmp-client/-/cmp-client-3.1.4.tgz",
+      "integrity": "sha512-UDLnyiJ1a+rrT9ao+50/OMS2WYYpaV3QWY354B8Bx6Mm91+IB1UEdU5C8NtYOMhARqDIhsG1TospTXc3OQZ9lg==",
       "dependencies": {
         "@iabtechlabtcf/core": "^1.5.10",
-        "next-session-client": "^5.0.0"
+        "next-session-client": "^5.0.0",
+        "uuid": "^9.0.1"
+      }
+    },
+    "node_modules/@financial-times/cmp-client/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@financial-times/flourish-receive-custom-analytics": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "@financial-times/g-components",
       "version": "0.0.0",
       "dependencies": {
-        "@financial-times/ads-legacy-o-ads": "5.2.2",
+        "@financial-times/ads-legacy-o-ads": "5.3.1",
+        "@financial-times/cmp-client": "^2.2.2",
         "@financial-times/flourish-receive-custom-analytics": "^1.2.0",
         "@financial-times/format-number": "^1.0.0",
         "@financial-times/ft-date-format": "^2.1.0",
@@ -2487,9 +2488,9 @@
       "dev": true
     },
     "node_modules/@financial-times/ads-legacy-o-ads": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@financial-times/ads-legacy-o-ads/-/ads-legacy-o-ads-5.2.2.tgz",
-      "integrity": "sha512-MIm3YA/juhipAqCSMTVAI/cLBP+rtsYeEwtiWIS23PpLsvjHTSL0I8dBC1SSoi38HaKJmUYGzvrDwFpLMhAPCA==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/ads-legacy-o-ads/-/ads-legacy-o-ads-5.3.1.tgz",
+      "integrity": "sha512-e7pUqxMkHCfD8jd4I7l6GTWZFF8B1/JfiXYQoktIrwrMsTgoKQNYCTY0y/HP6uRQqi0vf+Dh42ZQYZpYdg2MqQ==",
       "dependencies": {
         "@financial-times/o-utils": "^2.1.1",
         "@financial-times/o-viewport": "^5.1.1"
@@ -2501,6 +2502,15 @@
       "integrity": "sha512-LlAF8WShhWQamI9Xsk1ChxeF2YzmiCWBa01t3JBpupar+V96WbbpSV5Xsx5lrsbcRdu+EtOuR4zlujBU0niR4A==",
       "dependencies": {
         "@financial-times/privacy-legislation-client": "^1.0.0"
+      }
+    },
+    "node_modules/@financial-times/cmp-client": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@financial-times/cmp-client/-/cmp-client-2.2.2.tgz",
+      "integrity": "sha512-O9O3uWJ4q92JfxXXWvHlBLqA4jrgdd+RvycMz8y0VcECZLkikv9kfzKAi1DkavLfh65BTOedZgm+ddkyXYzNOg==",
+      "dependencies": {
+        "@iabtechlabtcf/core": "^1.5.10",
+        "next-session-client": "^5.0.0"
       }
     },
     "node_modules/@financial-times/flourish-receive-custom-analytics": {
@@ -3049,6 +3059,11 @@
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
       }
+    },
+    "node_modules/@iabtechlabtcf/core": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/@iabtechlabtcf/core/-/core-1.5.10.tgz",
+      "integrity": "sha512-HWenM2wC5wloQoAto3l/lX3H2uAB7qnoIsGAEd4J+OS74j/GlW3j7RYfMZ0JS//HEgJbW0P1jlbJ7oHRrEJoaw=="
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -17244,6 +17259,16 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "node_modules/next-session-client": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/next-session-client/-/next-session-client-5.0.0.tgz",
+      "integrity": "sha512-xkXekXRDB2k8OWj/7WHh37mV6PdAfLAdFd8f5usWaZtq+0LKHyx6mvO79/JdFvvJUod8IHOkQ+An64TpokBCFw==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": "16.x",
+        "npm": "7.x || 8.x"
+      }
     },
     "node_modules/node-dir": {
       "version": "0.1.17",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@financial-times/ads-legacy-o-ads": "5.3.1",
-    "@financial-times/cmp-client": "^2.2.2",
+    "@financial-times/cmp-client": "^3.1.4",
     "@financial-times/flourish-receive-custom-analytics": "^1.2.0",
     "@financial-times/format-number": "^1.0.0",
     "@financial-times/ft-date-format": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "react-dom": ">=17"
   },
   "dependencies": {
-    "@financial-times/ads-legacy-o-ads": "5.2.2",
+    "@financial-times/ads-legacy-o-ads": "5.3.1",
+    "@financial-times/cmp-client": "^2.2.2",
     "@financial-times/flourish-receive-custom-analytics": "^1.2.0",
     "@financial-times/format-number": "^1.0.0",
     "@financial-times/ft-date-format": "^2.1.0",

--- a/src/article-layout/index.jsx
+++ b/src/article-layout/index.jsx
@@ -20,9 +20,9 @@ export const Context = createContext({});
 
 const ArticleLayout = ({ flags, ads, children, ...props }) => {
   useEffect(() => {
-    if (flags.prod) {
+    if (flags.prod && flags.ads) {
       initSourcepointCmp({
-        propertyConfig: properties.FT_DOTCOM_PROD,
+        propertyConfig: properties.FT_DOTCOM_TEST,
       });
     }
   }, []);

--- a/src/article-layout/index.jsx
+++ b/src/article-layout/index.jsx
@@ -20,10 +20,12 @@ export const Context = createContext({});
 
 const ArticleLayout = ({ flags, ads, children, ...props }) => {
   useEffect(() => {
-    initSourcepointCmp({
-      propertyConfig: properties.FT_DOTCOM_PROD,
-      useConsentStore: false // (set to false e.g for non-FT.com properties or websites)
-    });
+    if (flags.prod) {
+      initSourcepointCmp({
+        propertyConfig: properties.FT_DOTCOM_PROD,
+        useConsentStore: false // (set to false e.g for non-FT.com properties or websites)
+      });
+    }
   }, []);
 
   const breakpoint = useLayoutChangeEvents();

--- a/src/article-layout/index.jsx
+++ b/src/article-layout/index.jsx
@@ -23,7 +23,6 @@ const ArticleLayout = ({ flags, ads, children, ...props }) => {
     if (flags.prod) {
       initSourcepointCmp({
         propertyConfig: properties.FT_DOTCOM_PROD,
-        useConsentStore: false // (set to false e.g for non-FT.com properties or websites)
       });
     }
   }, []);

--- a/src/article-layout/index.jsx
+++ b/src/article-layout/index.jsx
@@ -3,8 +3,9 @@
  * Article layout
  */
 
-import React, { createContext } from 'react';
+import React, { createContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { initSourcepointCmp, properties } from "@financial-times/cmp-client";
 import { flagsPropType, StringBoolPropType } from '../shared/proptypes';
 import Header from '../header';
 import Analytics from '../analytics';
@@ -18,6 +19,13 @@ import { useAds, useLayoutChangeEvents } from '../shared/hooks';
 export const Context = createContext({});
 
 const ArticleLayout = ({ flags, ads, children, ...props }) => {
+  useEffect(() => {
+    initSourcepointCmp({
+      propertyConfig: properties.FT_DOTCOM_PROD,
+      useConsentStore: false // (set to false e.g for non-FT.com properties or websites)
+    });
+  }, []);
+
   const breakpoint = useLayoutChangeEvents();
   useAds(ads, flags.ads);
 

--- a/src/article-layout/index.jsx
+++ b/src/article-layout/index.jsx
@@ -22,7 +22,7 @@ const ArticleLayout = ({ flags, ads, children, ...props }) => {
   useEffect(() => {
     if (flags.prod && flags.ads) {
       initSourcepointCmp({
-        propertyConfig: properties.FT_DOTCOM_TEST,
+        propertyConfig: properties.FT_DOTCOM_PROD,
       });
     }
   }, []);


### PR DESCRIPTION
This is based on the new consent migration guide: https://financialtimes.atlassian.net/wiki/spaces/ADS/pages/8151990292/New+Consent+Migration+Guide+for+teams

Find the CMP configuration options here: https://github.com/Financial-Times/privacy/tree/main/src/packages/cmp-client#cmp-configuration-options

This will trigger the new consent panel if we have the ads flag turned on (on by default) and it's built in prod (won't trigger when we're working locally).