### PR TITLE
Fix analytics code in SSR

### DIFF
--- a/src/analytics/index.jsx
+++ b/src/analytics/index.jsx
@@ -117,7 +117,8 @@ const Analytics = ({ id, tracking, flags, scrollDepthTarget }) => {
       <script
         dangerouslySetInnerHTML={{
           __html: `
-        var spoorId = /spoor-id=([^;]+)/.exec(document.cookie)[1] || 'cj5y2utdx00003i5z6l6po8c1';
+        var spoorCookie = /spoor-id=([^;]+)/.exec(document.cookie);
+        var spoorId = (spoorCookie && spoorCookie[1]) || 'cj5y2utdx00003i5z6l6po8c1';
         var endpoint = 'https://4235225.fls.doubleclick.net/activityi;src=4235225;type=homeo886;cat=ft-ne000;u10=' + spoorId + ';dc_lat=;dc_rdid=;tag_for_child_directed_treatment=;ord=' + Date.now() + ';num=1';
         var img = document.createElement('img');
         img.setAttribute('width', 1);

--- a/src/shared/helpers.jsx
+++ b/src/shared/helpers.jsx
@@ -22,7 +22,7 @@ export function encodedJSON(_data) {
 
 export function spoorTrackingPixel(data) {
   const jsonString = encodedJSON(data);
-  if (document) {
+  if (typeof document !== 'undefined') {
     const ieVersion = document.documentMode ? document.documentMode : 99; // eslint-disable-line
     const img = `<img src="https://spoor-api.ft.com/px.gif?data=${jsonString}" height="1" width="1" />`;
     return ieVersion < 9 ? img : <noscript data-o-component="o-tracking">{img}</noscript>;

--- a/src/shared/helpers.jsx
+++ b/src/shared/helpers.jsx
@@ -22,13 +22,12 @@ export function encodedJSON(_data) {
 
 export function spoorTrackingPixel(data) {
   const jsonString = encodedJSON(data);
-  if (typeof document !== 'undefined') {
-    const ieVersion = document.documentMode ? document.documentMode : 99; // eslint-disable-line
-    const img = `<img src="https://spoor-api.ft.com/px.gif?data=${jsonString}" height="1" width="1" />`;
-    return ieVersion < 9 ? img : <noscript data-o-component="o-tracking">{img}</noscript>;
-  }
 
-  return null;
+  return (
+    <noscript data-o-component="o-tracking">
+      <img src={`https://spoor-api.ft.com/px.gif?data=${jsonString}`} height="1" width="1" />
+    </noscript>
+  );
 }
 
 export function imageUUID(uuid) {


### PR DESCRIPTION
As mentioned in #244, I'm testing out server-side rendering using `vite` on a single project before we add it back into `starter-kit`. Along the way, I've been noticing (and fixing) little bugs in our dependencies to ensure their javascript is fully ismorphic on both the client and the server.

When testing out the production build of the project today, I realised that our tracking pixel code introduces an SSR bug — it includes a conditional `if (document)` that throws an error on the server, since it should be `if (typeof document === 'undefined')`. However, I then realised the code itself was a problem: it conditionally renders different things on the client and server, which causes a [hydration error](https://react.dev/reference/react-dom/client/hydrateRoot) when the client code attempts to reconcile the DOM with the server-rendered HTML.

<img width="800" alt="Screenshot 2023-11-25 at 23 01 59" src="https://github.com/Financial-Times/g-components/assets/3749412/e669630a-3d04-47c2-8663-6e520fc94b9b">

To fix, I decided to remove the entire `document` if-statement that renders the pixel differently on Internet Explorer 8 and below (which don't support `<noscript>` tags). Since that represents less than 0.05% of browsers in use today, it feels like a small loss, especially if it prevents the rest of the pages from properly loading their analytics in the first place. 

Notably, that `<noscript>` tag currently doesn't load _at all_ - since all of our pages are currently client-side, renders, browsers with no JS support currently don't get any tracking pixel. After this fix, we will at least get a tracking pixel that inside a server-rendered `<noscript>` tag, even if it no longer works on IE 8.

Additionally, I added a _tiny_ change to put a guard in front of some other spoor tracking pixel code, because it was throwing an error in the console when the regex did not match users' cookie.