### PR TITLE
Don't load comments before IG stories are published

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@financial-times/g-components",
-  "version": "9.2.0-canary.2",
+  "version": "9.2.0-canary.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@financial-times/g-components",
-      "version": "9.2.0-canary.2",
+      "version": "9.2.0-canary.3",
       "dependencies": {
         "@financial-times/ads-legacy-o-ads": "5.2.2",
         "@financial-times/flourish-receive-custom-analytics": "^1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@financial-times/g-components",
-  "version": "0.0.0",
+  "version": "9.2.0-canary.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@financial-times/g-components",
-      "version": "0.0.0",
+      "version": "9.2.0-canary.2",
       "dependencies": {
         "@financial-times/ads-legacy-o-ads": "5.2.2",
         "@financial-times/flourish-receive-custom-analytics": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/g-components",
-  "version": "9.1.5",
+  "version": "9.2.0-canary.2",
   "type": "module",
   "files": [
     "dist/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/g-components",
-  "version": "9.2.0-canary.2",
+  "version": "9.2.0-canary.3",
   "type": "module",
   "files": [
     "dist/",

--- a/src/comments/index.jsx
+++ b/src/comments/index.jsx
@@ -20,21 +20,17 @@ const Comments = ({ id, url, linkPageUrl, flags, openCommentsAt }) => {
     if (id && (url || linkPageUrl)) {
       const openTime = new Date(openCommentsAt || 0);
       // Switch to staging if comments are scheduled to go live in the future
-      const useStagingEnvironment = openTime > new Date();
-
-      if (useStagingEnvironment) {
+      if (openTime > new Date()) {
         setOpensAt(openTime);
       } else {
         setOpensAt(null);
+        new OComments(ref.current, {
+          // eslint-disable-line no-new
+          articleUrl: linkPageUrl || url,
+          articleId: id,
+          title: id,
+        });
       }
-
-      new OComments(ref.current, {
-        // eslint-disable-line no-new
-        articleUrl: linkPageUrl || url,
-        articleId: id,
-        title: id,
-        useStagingEnvironment,
-      });
     }
   }, [id, url, linkPageUrl, openCommentsAt]);
 
@@ -44,7 +40,7 @@ const Comments = ({ id, url, linkPageUrl, flags, openCommentsAt }) => {
         <div data-o-grid-colspan="12 S11 Scenter M9 L8 XL7">
           {opensAt && (
             <p className="g-comments__scheduled">
-              The live comments are scheduled to open on {format(opensAt)}.
+              The comments are scheduled to open on {format(opensAt)}.
             </p>
           )}
           <div ref={ref} data-o-component="o-comments" id="comments">

--- a/src/comments/index.jsx
+++ b/src/comments/index.jsx
@@ -3,35 +3,54 @@
  * Comments component
  */
 
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import OComments from '@financial-times/o-comments/main';
 import { flagsPropType } from '../shared/proptypes';
+import FTTimeFormat from '@financial-times/ft-date-format';
+const { format, ftTime } = FTTimeFormat;
 import './styles.scss';
 
-const Comments = ({ id, url, linkPageUrl, flags }) => {
+const Comments = ({ id, url, linkPageUrl, flags, openCommentsAt }) => {
   const ref = useRef();
-
   const { dark } = flags;
+  const [opensAt, setOpensAt] = useState(null);
 
   useEffect(() => {
-    if ((id && linkPageUrl) || (id && url)) {
+    if (id && (url || linkPageUrl)) {
+      const openTime = new Date(openCommentsAt || 0);
+      // Switch to staging if comments are scheduled to go live in the future
+      const useStagingEnvironment = openTime > new Date();
+
+      if (useStagingEnvironment) {
+        setOpensAt(openTime);
+      } else {
+        setOpensAt(null);
+      }
+
       new OComments(ref.current, {
         // eslint-disable-line no-new
         articleUrl: linkPageUrl || url,
         articleId: id,
         title: id,
+        useStagingEnvironment,
       });
     }
-  }, [id, url, linkPageUrl]);
+  }, [id, url, linkPageUrl, openCommentsAt]);
 
   const comments = (
     <div className="o-grid-container">
       <div className="o-grid-row">
         <div data-o-grid-colspan="12 S11 Scenter M9 L8 XL7">
+          {opensAt && (
+            <p className="g-comments__scheduled">
+              The live comments are scheduled to open on {format(opensAt)}.
+            </p>
+          )}
           <div ref={ref} data-o-component="o-comments" id="comments">
             <div className="o--if-no-js">
-              To participate in this chat, you need to upgrade to a newer web browser.{' '}
+              To participate in this chat, you need to enable javascript or upgrade to a newer web
+              browser.{' '}
               <a href="https://help.ft.com/tools-services/browser-compatibility/">Learn more.</a>
             </div>
           </div>
@@ -54,6 +73,7 @@ Comments.propTypes = {
   id: PropTypes.string.isRequired,
   url: PropTypes.string.isRequired,
   flags: flagsPropType,
+  openCommentsAt: PropTypes.string,
 };
 
 Comments.defaultProps = {
@@ -61,7 +81,7 @@ Comments.defaultProps = {
   flags: {
     dark: false,
   },
+  openCommentsAt: null,
 };
 
 export default Comments;
-Comments.displayName = 'GComments';

--- a/src/comments/styles.scss
+++ b/src/comments/styles.scss
@@ -7,3 +7,9 @@ $system-code: 'ig-content';
     'coral-talk-iframe': false,
   )
 );
+
+.g-comments__scheduled {
+  font-weight: 700;
+  margin: 16px;
+  color: #333;
+}

--- a/src/comments/styles.scss
+++ b/src/comments/styles.scss
@@ -9,7 +9,8 @@ $system-code: 'ig-content';
 );
 
 .g-comments__scheduled {
+  padding: 20px 16px;
+  background: #262a33;
+  color: white;
   font-weight: 700;
-  margin: 16px;
-  color: #333;
 }


### PR DESCRIPTION
Our IG publishing process has long had one annoying quirk: we've had to postpone publishing the `ig.ft.com` URL until shortly before publication, because doing so will begin the 48-hour commenting window. (This happens because the comments clock starts the first time the Coral iFrame is loaded — and due to the cross-origin rules, that only occurs when someone first loads the page on the live `ig.ft.com` domain.)

This PR adds a new (optional) prop to the `<Comments>` component: `openCommentsAt`. When passed a date object or string, the comments component will now compare that against the current time at page load — if the `openCommentsAt` date is in the future, ~it will load comments from the staging environment instead of prod.~ (It will also display a date announcing the scheduled comments opening time.)

**Update, 25 January:** After some testing, it appears that the staging Coral environment doesn't have `ig.ft.com` in it's CORS definition. After some discussion, I think it's better to simply refuse to load the comments and instead display a message until they are enabled:

<img width="1263" alt="Screenshot 2024-01-25 at 12 19 02" src="https://github.com/Financial-Times/g-components/assets/3749412/cfc3e437-09c1-4d63-9c15-97d5a03358fe">

This means that the prod comments will only be loaded _after_ the scheduled pub date — starting the 48-hour commenting window when the first person loads the page after the publication time.

If the prop is not provided the component will continue its current behaviour, so it should be fully backwards-compatible with existing stories.

(This PR is accompanied by a [sibling PR in starter-kit](https://github.com/ft-interactive/starter-kit/pull/324) to set this value by default using the `publishedDate` configuration.)