### PR TITLE
CI: Tag prerelease builds as "canary"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,9 +67,6 @@ jobs:
           name: Generate build
           command: npm run build
       - run:
-          name: Set package version from git
-          command: npx npm-prepublish --verbose
-      - run:
           name: Publish to NPM
           command: |
             if [[ $CIRCLE_TAG =~ canary ]]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 
-orbs: 
+orbs:
   node: circleci/node@4.7.0
 
 references:
@@ -67,8 +67,17 @@ jobs:
           name: Generate build
           command: npm run build
       - run:
-          name: Publish npm package
-          command: npx npm-prepublish --verbose && npm publish --access public
+          name: Set package version from git
+          command: npx npm-prepublish --verbose
+      - run:
+          name: Publish to NPM
+          command: |
+            if [[ $CIRCLE_TAG =~ canary ]]
+            then
+              npm publish --access public --tag canary
+            else
+              npm publish --access public --tag latest
+            fi
 
 workflows:
   version: 2
@@ -92,4 +101,3 @@ workflows:
               only: /^v.*/
             branches:
               ignore: /.*/
-

--- a/README.md
+++ b/README.md
@@ -63,7 +63,14 @@ $ npm link ../g-components
 
 # Releasing
 
-First make sure your local is up to date with the origin. Then update the snapshots:
+First make sure your local is up to date with the origin and that you're on the `main` branch:
+
+```bash
+$ git pull
+$ git checkout main
+```
+
+Then update the snapshots:
 
 ```bash
 $ npm run test -- -u
@@ -72,18 +79,20 @@ $ git commit -m 'Update snapshots'
 $ git push
 ```
 
-Check the last version number that was released:
+Next, run `npm version [major|minor|patch]` to increment the version based on the type of changes in this release. We use [Semantic Versioning](https://semver.org/) to increment versions:
 
-```bash
-$ git describe --tags
-```
+- Breaking (non-backwards-compatible) changes should be a `major` release
+- New features (that are backwards-compatible) should be `minor`
+- Bug fixes should be a `patch`
+- Alternatively, you can use `npm version vX.X.X` to set the version yourself.
 
-Then release the next version, replacing v9.9.9 with the actual number:
+Finally, run `git push --follow-tags` to push the new version to GitHub, which will trigger the CircleCI pipeline that publishes the new version on NPM.
 
-```bash
-$ git tag v9.9.9
-$ git push origin v9.9.9
-```
+### Pre-release ("canary") versions
+
+If you'd like to release a pre-release version (e.g. to test or gradually roll out a new feature), you can create a new version like `npm version v1.0.0-canary.0`. The version number should represent the ultimate release this change will land in, while the final `0` can be incremented to make subsequent prerelease builds.
+
+NPM can also generate this automatically for you, with `npm version pre[major|minor|patch] --preid canary`.
 
 # Licence
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/g-components",
-  "version": "0.0.0",
+  "version": "9.1.5",
   "type": "module",
   "files": [
     "dist/",


### PR DESCRIPTION
This morning, I attempted to push a canary build to NPM to test a branch — and quickly discovered that NPM tagged that build with `latest` - thereby making it the default version installed when anyone runs `npm i @financial-times/g-components`. 

This tweak to the CircleCI config will tag canary versions with the `canary` tag, while ensuring other versions continue to be tagged with `latest`. (I've also made that tag explicit, rather than relying on the hidden default.)