### PR TITLE
Fix date hydration error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@financial-times/g-components",
-  "version": "9.4.0",
+  "version": "9.4.1-canary.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@financial-times/g-components",
-      "version": "9.4.0",
+      "version": "9.4.1-canary.0",
       "dependencies": {
         "@financial-times/ads-legacy-o-ads": "5.3.1",
         "@financial-times/cmp-client": "^3.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/g-components",
-  "version": "9.4.0",
+  "version": "9.4.1-canary.0",
   "type": "module",
   "files": [
     "dist/",

--- a/src/datetime/index.jsx
+++ b/src/datetime/index.jsx
@@ -21,6 +21,7 @@ const DateTime = ({ datestamp }) => {
       data-o-component="o-date"
       className="o-date"
       dateTime={datestamp.toISOString()}
+      suppressHydrationWarning
     >
       {ftDateFormat.ftTime(datestamp)}
     </time>


### PR DESCRIPTION
The `O-Date` component is causing yet another SSR issue, because the server renders a relative time (e.g. `4 hours ago`) which quickly becomes out-of-date — then the client renders something else. This causes a hydration error, and negates many of the performance benefits of server-side rendering - so it's definitely not desirable

<img width="1588" alt="Screenshot 2024-03-01 at 11 51 22" src="https://github.com/Financial-Times/g-components/assets/3749412/3f4571d2-d546-4a7e-978e-c0bdab8d97ee">

I'm currently testing this fix, which _should_ work by simply warning React in advance that the contents may be different.

