### PR TITLE
Fix two little o-share errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@financial-times/g-components",
-  "version": "9.4.1-canary.0",
+  "version": "9.4.1-canary.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@financial-times/g-components",
-      "version": "9.4.1-canary.0",
+      "version": "9.4.1-canary.1",
       "dependencies": {
         "@financial-times/ads-legacy-o-ads": "5.3.1",
         "@financial-times/cmp-client": "^3.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/g-components",
-  "version": "9.4.1-canary.0",
+  "version": "9.4.1-canary.1",
   "type": "module",
   "files": [
     "dist/",

--- a/src/share/index.jsx
+++ b/src/share/index.jsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useEffect, useRef } from 'react';
-// import OShare from '@financial-times/o-share/main';
+import OShare from '@financial-times/o-share/main';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import './styles.scss';
@@ -87,7 +87,7 @@ const Share = ({
                 href={link}
                 rel="noopener"
               >
-                <div class="o-share__icon__image">{icon}</div>
+                <div className="o-share__icon__image">{icon}</div>
                 <span className="o-share__text">Share on {name}. Opens in a new window.</span>
               </a>
             </li>


### PR DESCRIPTION
This fixes two little OShare errors I was seeing in the console:

1. `OShare is not defined` - this appears to be because the import line is commented out? I'm not sure if there was a reason it was removed in #254, but it _feels_ like it should probably be imported? (I totally missed this in my review!)

2. `Invalid DOM property 'class'. Did you mean 'className'` - this is straightforward enough to fix